### PR TITLE
feat: interlocked docs-as-fixtures with self-contained e2e and examples

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,20 @@
+name: Deploy docs to GitHub Pages
+on:
+  push:
+    branches: [master]
+permissions:
+  pages: write
+  id-token: write
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v3
+        with: { path: docs/ }
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ data
 # Build / scrape output
 dist/
 output/
+# Example output files are committed as documentation of expected output shape
+!examples/**/output/
+!examples/**/output/**
 
 # Compiled plugin outputs (built from plugins/**/*.ts via tsconfig.plugins.json)
 plugins/**/*.js

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -84,8 +84,9 @@ graph TD
         </div>
       </section>
 
-      <section id="pipeline">
+      <section id="pipeline" data-component="pipeline">
         <h2>Pipeline pattern</h2>
+        <p class="summary">Typed async middleware chain where every task receives (next, state) and advances the queue by calling next().</p>
         <p>The core architecture is a typed middleware chain inherited from PathRipper's <code>Transformer</code> class, rewritten in TypeScript. Every task receives <code>(next, state)</code>. Calling <code>next()</code> advances to the next task; not calling it terminates the chain.</p>
 
         <div class="mermaid">
@@ -120,8 +121,9 @@ await pipeline.execute(PipelineState.fromWikiPage('my-target', page));</code></p
         <p><code>TState</code> must extend <code>Record&lt;string, unknown&gt;</code>. Tasks mutate state directly — the pipeline passes the same reference through the chain.</p>
       </section>
 
-      <section id="http-layer">
+      <section id="http-layer" data-component="http">
         <h2>HTTP machinery</h2>
+        <p class="summary">Three composable classes — RateLimiter, RetryExecutor, and ErrorClassifier — form the HTTP stack, each injected independently.</p>
         <p>Three classes form the HTTP stack, ported from <a href="https://github.com/Studnicky/torus">Torus</a>. They're independent of each other and compose by injection.</p>
 
         <div class="mermaid">
@@ -166,8 +168,9 @@ graph LR
         <p>Token-bucket backed by <code>bottleneck</code>. Factory methods: <code>RateLimiter.perSecond(n)</code> for throughput-based limits, <code>RateLimiter.withDelay(ms)</code> for fixed-gap limits. Used by every scraper and crawler.</p>
       </section>
 
-      <section id="scrapers">
+      <section id="scrapers" data-component="scrapers">
         <h2>Scrapers</h2>
+        <p class="summary">Pure data accessors for HTML (via cheerio) and MediaWiki (via native fetch) that return typed results without coupling to the pipeline.</p>
 
         <h3>HtmlScraper</h3>
         <p>Native <code>fetch</code> + <code>cheerio</code>. Returns <code>ScrapedPageInterface { url, $, html }</code>. The <code>$</code> field is a live <code>CheerioAPI</code> handle — use it exactly as you'd use jQuery on a DOM. No browser engine, no JavaScript execution. For JS-rendered pages, swap the fetch call for a headless driver (Playwright, Puppeteer) and feed the HTML to <code>cheerio.load()</code>.</p>
@@ -186,8 +189,9 @@ graph LR
         <p>Wraps <code>wtf_wikipedia</code>. <code>WikitextParser.parse(title, wikitext)</code> returns a <code>ParsedPageInterface</code> with <code>infobox</code> (flat key→value record), <code>sections</code> (title + raw wikitext), and <code>categories</code>. Helper methods <code>infoboxField</code> and <code>infoboxNumber</code> pull typed values without null-checks at call site.</p>
       </section>
 
-      <section id="crawler">
+      <section id="crawler" data-component="crawler">
         <h2>Link crawler</h2>
+        <p class="summary">Recursive link crawler controlled by three regexes (domain, delimiter, target) that bound traversal and collect matching URLs.</p>
         <p>Modernized from PathRipper's <code>LinkLister</code>. Three regexes control behavior:</p>
         <table>
           <thead><tr><th>Regex</th><th>Purpose</th></tr></thead>
@@ -200,8 +204,9 @@ graph LR
         <p>Visited URLs are tracked in a <code>Set</code>. All traversals run concurrently via <code>Promise.all</code> at each level. Results are deduplicated and sorted with a numeric-aware collator — so <code>Item-10</code> sorts after <code>Item-9</code>, not between <code>Item-1</code> and <code>Item-2</code>.</p>
       </section>
 
-      <section id="source-map">
+      <section id="source-map" data-component="source-map">
         <h2>Source map</h2>
+        <p class="summary">Complete index of every source file, its exported symbols, and the PathRipper or Torus module it was ported from.</p>
         <table>
           <thead><tr><th>File</th><th>Exports</th><th>Ported from</th></tr></thead>
           <tbody>

--- a/examples/docs-scraper/README.md
+++ b/examples/docs-scraper/README.md
@@ -1,0 +1,32 @@
+# docs-scraper example
+
+Demonstrates extracting structured data from HTML documentation pages that use `section[data-component]` markup.
+
+## What it demonstrates
+
+- Writing a `docs:parse` plugin that operates on HTML state
+- Using cheerio selectors inside a pipeline task
+- Extracting `data-component` attributes and `p.summary` text for deterministic output
+- The docs site at `https://studnicky.github.io/PathRipper/` is both the live documentation AND the HTML fixture for the e2e test
+
+## Running the e2e test
+
+The e2e test for this example scrapes the live docs site:
+
+```
+RIPPER_E2E=1 npm run test:e2e -- --test-name-pattern='docs-html'
+```
+
+## Output shape
+
+Each section produces:
+
+```json
+{
+  "_type": "docs_section",
+  "component": "pipeline",
+  "title": "Pipeline pattern",
+  "description": "Typed async middleware chain where every task receives (next, state) and advances the queue by calling next().",
+  "url": "https://studnicky.github.io/PathRipper/architecture.html"
+}
+```

--- a/examples/docs-scraper/config.example.json
+++ b/examples/docs-scraper/config.example.json
@@ -1,0 +1,10 @@
+{
+  "output": { "basePath": "./examples/docs-scraper/output" },
+  "targets": {
+    "ripperoni-docs": {
+      "baseUrl": "https://studnicky.github.io/PathRipper",
+      "rateLimitMs": 500,
+      "pipeline": ["./examples/docs-scraper/plugin.js"]
+    }
+  }
+}

--- a/examples/docs-scraper/output/architecture.json
+++ b/examples/docs-scraper/output/architecture.json
@@ -1,0 +1,39 @@
+{
+  "sections": [
+    {
+      "_type": "docs_section",
+      "component": "pipeline",
+      "title": "Pipeline pattern",
+      "description": "Typed async middleware chain where every task receives (next, state) and advances the queue by calling next().",
+      "url": "https://studnicky.github.io/PathRipper/architecture.html"
+    },
+    {
+      "_type": "docs_section",
+      "component": "http",
+      "title": "HTTP machinery",
+      "description": "Three composable classes — RateLimiter, RetryExecutor, and ErrorClassifier — form the HTTP stack, each injected independently.",
+      "url": "https://studnicky.github.io/PathRipper/architecture.html"
+    },
+    {
+      "_type": "docs_section",
+      "component": "scrapers",
+      "title": "Scrapers",
+      "description": "Pure data accessors for HTML (via cheerio) and MediaWiki (via native fetch) that return typed results without coupling to the pipeline.",
+      "url": "https://studnicky.github.io/PathRipper/architecture.html"
+    },
+    {
+      "_type": "docs_section",
+      "component": "crawler",
+      "title": "Link crawler",
+      "description": "Recursive link crawler controlled by three regexes (domain, delimiter, target) that bound traversal and collect matching URLs.",
+      "url": "https://studnicky.github.io/PathRipper/architecture.html"
+    },
+    {
+      "_type": "docs_section",
+      "component": "source-map",
+      "title": "Source map",
+      "description": "Complete index of every source file, its exported symbols, and the PathRipper or Torus module it was ported from.",
+      "url": "https://studnicky.github.io/PathRipper/architecture.html"
+    }
+  ]
+}

--- a/examples/docs-scraper/plugin.js
+++ b/examples/docs-scraper/plugin.js
@@ -1,0 +1,33 @@
+// docs-scraper plugin — registered as `docs:parse`
+// Extracts structured data from HTML pages that have `section[data-component]` markup,
+// as used in the Ripperoni architecture docs at https://studnicky.github.io/PathRipper/
+//
+// Self-registers on import so the TaskRegistry can find it by name.
+import { load } from 'cheerio';
+import { TaskRegistry } from '../../src/registry/TaskRegistry.js';
+TaskRegistry.register('docs:parse', async (next, state) => {
+    const html = state.page.html ?? '';
+    const url = state.page.url;
+    const $ = load(html);
+    const results = [];
+    $('section[data-component]').each((_i, el) => {
+        const section = $(el);
+        const component = section.attr('data-component') ?? '';
+        const title = section.find('h2').first().text().trim();
+        const summary = section.find('p.summary').first().text().trim();
+        if (component.length > 0) {
+            results.push({ _type: 'docs_section', component, title, description: summary, url });
+        }
+    });
+    if (results.length > 0) {
+        state.output = results[0];
+        // Store all sections on the state for the e2e test to inspect
+        state['sections'] = results;
+    }
+    else {
+        const pageTitle = $('h1').first().text().trim();
+        const output = { _type: 'docs_page', url, title: pageTitle };
+        state.output = output;
+    }
+    await next();
+});

--- a/examples/docs-scraper/plugin.ts
+++ b/examples/docs-scraper/plugin.ts
@@ -1,0 +1,58 @@
+// docs-scraper plugin — registered as `docs:parse`
+// Extracts structured data from HTML pages that have `section[data-component]` markup,
+// as used in the Ripperoni architecture docs at https://studnicky.github.io/PathRipper/
+//
+// Self-registers on import so the TaskRegistry can find it by name.
+
+import { load } from 'cheerio';
+
+import { TaskRegistry } from '../../src/registry/TaskRegistry.js';
+import type { PipelineStateInterface } from '../../src/types/PipelineState.js';
+import type { NextFnInterface } from '../../src/types/Pipeline.js';
+
+interface DocsSectionOutput {
+  readonly _type: 'docs_section';
+  readonly component: string;
+  readonly title: string;
+  readonly description: string;
+  readonly url: string;
+}
+
+interface DocsPageOutput {
+  readonly _type: 'docs_page';
+  readonly url: string;
+  readonly title: string;
+}
+
+type DocsOutput = DocsSectionOutput | DocsPageOutput;
+
+TaskRegistry.register('docs:parse', async (next: NextFnInterface, state: PipelineStateInterface): Promise<void> => {
+  const html = state.page.html ?? '';
+  const url  = state.page.url;
+  const $    = load(html);
+
+  const results: DocsOutput[] = [];
+
+  $('section[data-component]').each((_i: number, el: unknown) => {
+    const section   = $(el as Parameters<typeof $>[0]);
+    const component = section.attr('data-component') ?? '';
+    const title     = section.find('h2').first().text().trim();
+    const summary   = section.find('p.summary').first().text().trim();
+
+    if (component.length > 0) {
+      results.push({ _type: 'docs_section', component, title, description: summary, url });
+    }
+  });
+
+  if (results.length > 0) {
+    state.output = results[0] as unknown as Record<string, unknown>;
+    // Store all sections on the state for the e2e test to inspect
+    (state as Record<string, unknown>)['sections'] = results;
+  } else {
+    const pageTitle = $('h1').first().text().trim();
+    const output: DocsPageOutput = { _type: 'docs_page', url, title: pageTitle };
+    state.output = output as unknown as Record<string, unknown>;
+  }
+
+  await next();
+});

--- a/examples/wiki-docs/README.md
+++ b/examples/wiki-docs/README.md
@@ -1,0 +1,44 @@
+# wiki-docs example
+
+Demonstrates extracting structured component metadata from MediaWiki pages that use the `{{RipperoniComponent}}` infobox template.
+
+## What it demonstrates
+
+- Writing a `wiki-docs:parse` plugin that operates on wikitext state
+- Using `wtf_wikipedia` template parsing inside a pipeline task
+- The fixture server in `tests/e2e/fixtures/wiki/` provides a self-contained MediaWiki API mock — no external network required
+
+## Running the e2e test
+
+The e2e test uses the local fixture server (no external network):
+
+```
+npm run test:e2e -- --test-name-pattern='wiki-docs'
+```
+
+## Template format
+
+Pages should use the `{{RipperoniComponent}}` infobox:
+
+```wikitext
+{{RipperoniComponent
+|name=Pipeline
+|kind=Core
+|since=2.0.0
+|description=Typed async middleware chain. Tasks receive (next, state) and advance via next().
+|source=src/pipeline/Pipeline.ts
+}}
+```
+
+## Output shape
+
+```json
+{
+  "_type": "ripperoni_component",
+  "name": "Pipeline",
+  "kind": "Core",
+  "since": "2.0.0",
+  "description": "Typed async middleware chain. Tasks receive (next, state) and advance via next().",
+  "source": "src/pipeline/Pipeline.ts"
+}
+```

--- a/examples/wiki-docs/config.example.json
+++ b/examples/wiki-docs/config.example.json
@@ -1,0 +1,10 @@
+{
+  "output": { "basePath": "./examples/wiki-docs/output" },
+  "mediawiki": {
+    "ripperoni-wiki": {
+      "apiUrl": "http://localhost:9876/w/api.php",
+      "rateLimitMs": 50,
+      "pipeline": ["./examples/wiki-docs/plugin.js"]
+    }
+  }
+}

--- a/examples/wiki-docs/output/htmlscraper.json
+++ b/examples/wiki-docs/output/htmlscraper.json
@@ -1,0 +1,8 @@
+{
+  "_type": "ripperoni_component",
+  "name": "HtmlScraper",
+  "kind": "Scraper",
+  "since": "2.0.0",
+  "description": "Fetches and parses HTML pages using native fetch and cheerio with rate limiting and retry support.",
+  "source": "src/scrapers/HtmlScraper.ts"
+}

--- a/examples/wiki-docs/output/linklister.json
+++ b/examples/wiki-docs/output/linklister.json
@@ -1,0 +1,8 @@
+{
+  "_type": "ripperoni_component",
+  "name": "LinkLister",
+  "kind": "Crawler",
+  "since": "2.0.0",
+  "description": "Recursive link crawler controlled by three regexes — domain, delimiter, target — that bound traversal scope and collect matching URLs.",
+  "source": "src/crawlers/LinkLister.ts"
+}

--- a/examples/wiki-docs/output/mediawikiscraper.json
+++ b/examples/wiki-docs/output/mediawikiscraper.json
@@ -1,0 +1,8 @@
+{
+  "_type": "ripperoni_component",
+  "name": "MediaWikiScraper",
+  "kind": "Scraper",
+  "since": "2.0.0",
+  "description": "Fetches wikitext from a MediaWiki action API using native fetch with pagination and batch support.",
+  "source": "src/scrapers/MediaWikiScraper.ts"
+}

--- a/examples/wiki-docs/output/pipeline.json
+++ b/examples/wiki-docs/output/pipeline.json
@@ -1,0 +1,8 @@
+{
+  "_type": "ripperoni_component",
+  "name": "Pipeline",
+  "kind": "Core",
+  "since": "2.0.0",
+  "description": "Typed async middleware chain. Tasks receive (next, state) and advance via next.",
+  "source": "src/pipeline/Pipeline.ts"
+}

--- a/examples/wiki-docs/output/taskregistry.json
+++ b/examples/wiki-docs/output/taskregistry.json
@@ -1,0 +1,8 @@
+{
+  "_type": "ripperoni_component",
+  "name": "TaskRegistry",
+  "kind": "Core",
+  "since": "2.0.0",
+  "description": "Global static registry mapping task names to pipeline task functions, loaded dynamically from plugin files.",
+  "source": "src/registry/TaskRegistry.ts"
+}

--- a/examples/wiki-docs/plugin.js
+++ b/examples/wiki-docs/plugin.js
@@ -1,0 +1,37 @@
+// wiki-docs plugin — registered as `wiki-docs:parse`
+// Extracts structured data from wikitext pages that use the {{RipperoniComponent}} infobox template.
+// Designed to work against the wiki fixture server in tests/e2e/fixtures/wiki/ and any
+// real MediaWiki instance that uses the same template.
+//
+// Self-registers on import so the TaskRegistry can find it by name.
+import wtf from 'wtf_wikipedia';
+import { TaskRegistry } from '../../src/registry/TaskRegistry.js';
+const TEMPLATE_MARKER = '{{RipperoniComponent';
+TaskRegistry.register('wiki-docs:parse', async (next, state) => {
+    const wikitext = state.page.wikitext ?? '';
+    const title = state.page.title;
+    if (wikitext.includes(TEMPLATE_MARKER)) {
+        const doc = wtf(wikitext);
+        const templates = doc.templates();
+        for (const template of templates) {
+            const data = template.json();
+            if (data['template'] === 'ripperonicomponent') {
+                const output = {
+                    _type: 'ripperoni_component',
+                    name: data['name'] ?? title,
+                    kind: data['kind'] ?? '',
+                    since: data['since'] ?? '',
+                    description: data['description'] ?? '',
+                    source: data['source'] ?? '',
+                };
+                state.output = output;
+                await next();
+                return;
+            }
+        }
+    }
+    // No recognized template — return raw page output
+    const fallback = { _type: 'raw_page', title, wikitext };
+    state.output = fallback;
+    await next();
+});

--- a/examples/wiki-docs/plugin.ts
+++ b/examples/wiki-docs/plugin.ts
@@ -1,0 +1,61 @@
+// wiki-docs plugin — registered as `wiki-docs:parse`
+// Extracts structured data from wikitext pages that use the {{RipperoniComponent}} infobox template.
+// Designed to work against the wiki fixture server in tests/e2e/fixtures/wiki/ and any
+// real MediaWiki instance that uses the same template.
+//
+// Self-registers on import so the TaskRegistry can find it by name.
+
+import wtf from 'wtf_wikipedia';
+
+import { TaskRegistry } from '../../src/registry/TaskRegistry.js';
+import type { PipelineStateInterface } from '../../src/types/PipelineState.js';
+import type { NextFnInterface } from '../../src/types/Pipeline.js';
+
+const TEMPLATE_MARKER = '{{RipperoniComponent';
+
+interface RipperoniComponentOutput {
+  readonly _type: 'ripperoni_component';
+  readonly name: string;
+  readonly kind: string;
+  readonly since: string;
+  readonly description: string;
+  readonly source: string;
+}
+
+interface RawPageOutput {
+  readonly _type: 'raw_page';
+  readonly title: string;
+  readonly wikitext: string;
+}
+
+TaskRegistry.register('wiki-docs:parse', async (next: NextFnInterface, state: PipelineStateInterface): Promise<void> => {
+  const wikitext = state.page.wikitext ?? '';
+  const title    = state.page.title;
+
+  if (wikitext.includes(TEMPLATE_MARKER)) {
+    const doc       = wtf(wikitext);
+    const templates = doc.templates();
+
+    for (const template of templates) {
+      const data = template.json() as Record<string, string>;
+      if (data['template'] === 'ripperonicomponent') {
+        const output: RipperoniComponentOutput = {
+          _type:       'ripperoni_component',
+          name:        data['name']        ?? title,
+          kind:        data['kind']        ?? '',
+          since:       data['since']       ?? '',
+          description: data['description'] ?? '',
+          source:      data['source']      ?? '',
+        };
+        state.output = output as unknown as Record<string, unknown>;
+        await next();
+        return;
+      }
+    }
+  }
+
+  // No recognized template — return raw page output
+  const fallback: RawPageOutput = { _type: 'raw_page', title, wikitext };
+  state.output = fallback as unknown as Record<string, unknown>;
+  await next();
+});

--- a/tests/e2e/docs-html.test.ts
+++ b/tests/e2e/docs-html.test.ts
@@ -1,0 +1,83 @@
+// HTML scraper e2e test against the live PathRipper docs site.
+// Exercises the docs-scraper example plugin against real structured content.
+//
+// Requires network access to https://studnicky.github.io/PathRipper/
+//
+// Run locally:
+//   RIPPER_E2E=1 npm run test:e2e -- --test-name-pattern='docs-html'
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFile, mkdir } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { HtmlScraper } from '../../src/scrapers/HtmlScraper.js';
+import { Pipeline } from '../../src/pipeline/Pipeline.js';
+import { PipelineState } from '../../src/registry/PipelineState.js';
+import { TaskRegistry } from '../../src/registry/TaskRegistry.js';
+import type { PipelineStateInterface } from '../../src/types/PipelineState.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BASE_URL  = 'https://studnicky.github.io/PathRipper';
+const OUT_DIR   = resolve(__dirname, '../../examples/docs-scraper/output');
+
+interface DocsSectionOutput {
+  _type: 'docs_section';
+  component: string;
+  title: string;
+  description: string;
+  url: string;
+}
+
+describe('docs-html e2e — HTML scraper against live PathRipper docs', { skip: process.env['RIPPER_E2E'] !== '1' }, () => {
+  before(async () => {
+    // Load the example plugin — it self-registers `docs:parse`
+    await import('../../examples/docs-scraper/plugin.js');
+    await mkdir(OUT_DIR, { recursive: true });
+  });
+
+  it('fetches architecture.html and extracts at least 3 data-component sections', async () => {
+    const scraper = HtmlScraper.create({ baseUrl: BASE_URL, rateLimitMs: 500 });
+
+    const page = await scraper.fetchPage('/architecture.html');
+
+    TaskRegistry.reset();
+    await import('../../examples/docs-scraper/plugin.js');
+
+    const state: PipelineStateInterface = {
+      ...PipelineState.fromHtmlUrl('ripperoni-docs', page.url),
+      page: {
+        targetId: 'ripperoni-docs',
+        title:    'Architecture',
+        url:      page.url,
+        html:     page.html,
+      },
+    };
+
+    const pipeline = Pipeline.create<PipelineStateInterface>({ name: 'docs-html-e2e' });
+    pipeline.addTask(TaskRegistry.get('docs:parse'));
+    await pipeline.execute(state);
+
+    const sections = (state as Record<string, unknown>)['sections'] as DocsSectionOutput[] | undefined;
+    assert.ok(sections !== undefined && sections.length >= 3,
+      `expected at least 3 sections, got ${String(sections?.length ?? 0)}`);
+
+    const firstSection = sections[0];
+    assert.ok(firstSection !== undefined, 'expected at least one section');
+    assert.equal(firstSection._type, 'docs_section');
+    assert.ok(firstSection.component.length > 0, 'section should have a component identifier');
+    assert.ok(firstSection.title.length > 0, 'section should have a title');
+    assert.ok(firstSection.description.length > 0, 'section should have a description');
+    assert.equal(firstSection.url, `${BASE_URL}/architecture.html`);
+
+    process.stdout.write(`\n  docs-html: extracted ${sections.length.toString()} sections from architecture.html\n`);
+    for (const s of sections) {
+      process.stdout.write(`    • [${s.component}] ${s.title}\n`);
+    }
+
+    const outputPath = resolve(OUT_DIR, 'architecture.json');
+    await writeFile(outputPath, JSON.stringify({ sections }, null, 2));
+    process.stdout.write(`  wrote: ${outputPath}\n`);
+  });
+});

--- a/tests/e2e/fixtures/wiki/data/allpages.json
+++ b/tests/e2e/fixtures/wiki/data/allpages.json
@@ -1,0 +1,7 @@
+{ "query": { "allpages": [
+  { "pageid": 1, "ns": 0, "title": "Pipeline" },
+  { "pageid": 2, "ns": 0, "title": "HtmlScraper" },
+  { "pageid": 3, "ns": 0, "title": "MediaWikiScraper" },
+  { "pageid": 4, "ns": 0, "title": "LinkLister" },
+  { "pageid": 5, "ns": 0, "title": "TaskRegistry" }
+]}}

--- a/tests/e2e/fixtures/wiki/data/categorymembers.json
+++ b/tests/e2e/fixtures/wiki/data/categorymembers.json
@@ -1,0 +1,7 @@
+{ "query": { "categorymembers": [
+  { "pageid": 1, "ns": 0, "title": "Pipeline" },
+  { "pageid": 2, "ns": 0, "title": "HtmlScraper" },
+  { "pageid": 3, "ns": 0, "title": "MediaWikiScraper" },
+  { "pageid": 4, "ns": 0, "title": "LinkLister" },
+  { "pageid": 5, "ns": 0, "title": "TaskRegistry" }
+]}}

--- a/tests/e2e/fixtures/wiki/data/pages/htmlscraper.json
+++ b/tests/e2e/fixtures/wiki/data/pages/htmlscraper.json
@@ -1,0 +1,16 @@
+{
+  "query": {
+    "pages": {
+      "2": {
+        "pageid": 2,
+        "ns": 0,
+        "title": "HtmlScraper",
+        "revisions": [
+          {
+            "*": "{{RipperoniComponent\n|name=HtmlScraper\n|kind=Scraper\n|since=2.0.0\n|description=Fetches and parses HTML pages using native fetch and cheerio with rate limiting and retry support.\n|source=src/scrapers/HtmlScraper.ts\n}}"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/e2e/fixtures/wiki/data/pages/linklister.json
+++ b/tests/e2e/fixtures/wiki/data/pages/linklister.json
@@ -1,0 +1,16 @@
+{
+  "query": {
+    "pages": {
+      "4": {
+        "pageid": 4,
+        "ns": 0,
+        "title": "LinkLister",
+        "revisions": [
+          {
+            "*": "{{RipperoniComponent\n|name=LinkLister\n|kind=Crawler\n|since=2.0.0\n|description=Recursive link crawler controlled by three regexes — domain, delimiter, target — that bound traversal scope and collect matching URLs.\n|source=src/crawlers/LinkLister.ts\n}}"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/e2e/fixtures/wiki/data/pages/mediawikiscraper.json
+++ b/tests/e2e/fixtures/wiki/data/pages/mediawikiscraper.json
@@ -1,0 +1,16 @@
+{
+  "query": {
+    "pages": {
+      "3": {
+        "pageid": 3,
+        "ns": 0,
+        "title": "MediaWikiScraper",
+        "revisions": [
+          {
+            "*": "{{RipperoniComponent\n|name=MediaWikiScraper\n|kind=Scraper\n|since=2.0.0\n|description=Fetches wikitext from a MediaWiki action API using native fetch with pagination and batch support.\n|source=src/scrapers/MediaWikiScraper.ts\n}}"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/e2e/fixtures/wiki/data/pages/pipeline.json
+++ b/tests/e2e/fixtures/wiki/data/pages/pipeline.json
@@ -1,0 +1,16 @@
+{
+  "query": {
+    "pages": {
+      "1": {
+        "pageid": 1,
+        "ns": 0,
+        "title": "Pipeline",
+        "revisions": [
+          {
+            "*": "{{RipperoniComponent\n|name=Pipeline\n|kind=Core\n|since=2.0.0\n|description=Typed async middleware chain. Tasks receive (next, state) and advance via next().\n|source=src/pipeline/Pipeline.ts\n}}"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/e2e/fixtures/wiki/data/pages/taskregistry.json
+++ b/tests/e2e/fixtures/wiki/data/pages/taskregistry.json
@@ -1,0 +1,16 @@
+{
+  "query": {
+    "pages": {
+      "5": {
+        "pageid": 5,
+        "ns": 0,
+        "title": "TaskRegistry",
+        "revisions": [
+          {
+            "*": "{{RipperoniComponent\n|name=TaskRegistry\n|kind=Core\n|since=2.0.0\n|description=Global static registry mapping task names to pipeline task functions, loaded dynamically from plugin files.\n|source=src/registry/TaskRegistry.ts\n}}"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/e2e/fixtures/wiki/server.ts
+++ b/tests/e2e/fixtures/wiki/server.ts
@@ -1,0 +1,145 @@
+// Minimal built-in HTTP server that serves pre-built MediaWiki API JSON
+// for the ripperoni documentation fixture. Uses node:http only — no external deps.
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseQs } from 'node:querystring';
+
+const DATA_DIR = resolve(dirname(fileURLToPath(import.meta.url)), 'data');
+
+export interface WikiFixtureServerInterface {
+  readonly port: number;
+  readonly baseUrl: string;
+  close(): Promise<void>;
+}
+
+async function readJson(filePath: string): Promise<unknown> {
+  const raw = await readFile(filePath, 'utf-8');
+  return JSON.parse(raw) as unknown;
+}
+
+function titleToFilename(title: string): string {
+  return title.toLowerCase().replace(/\s+/g, '') + '.json';
+}
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const raw = req.url ?? '/';
+  const qstart = raw.indexOf('?');
+  const qs = qstart >= 0 ? raw.slice(qstart + 1) : '';
+  const params = parseQs(qs) as Record<string, string | string[]>;
+
+  function param(key: string): string {
+    const v = params[key];
+    return Array.isArray(v) ? (v[0] ?? '') : (v ?? '');
+  }
+
+  const action = param('action');
+  const list   = param('list');
+  const prop   = param('prop');
+
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+
+  if (action !== 'query') {
+    res.writeHead(400);
+    res.end(JSON.stringify({ error: { code: 'unknown_action', info: `Unknown action: ${action}` } }));
+    return;
+  }
+
+  // action=query&list=categorymembers → return categorymembers.json
+  if (list === 'categorymembers') {
+    try {
+      const data = await readJson(resolve(DATA_DIR, 'categorymembers.json'));
+      res.writeHead(200);
+      res.end(JSON.stringify(data));
+    } catch {
+      res.writeHead(500);
+      res.end(JSON.stringify({ error: 'categorymembers fixture not found' }));
+    }
+    return;
+  }
+
+  // action=query&list=allpages → return allpages.json
+  if (list === 'allpages') {
+    try {
+      const data = await readJson(resolve(DATA_DIR, 'allpages.json'));
+      res.writeHead(200);
+      res.end(JSON.stringify(data));
+    } catch {
+      res.writeHead(500);
+      res.end(JSON.stringify({ error: 'allpages fixture not found' }));
+    }
+    return;
+  }
+
+  // action=query&prop=revisions&titles=... → look up each title, merge pages
+  if (prop === 'revisions') {
+    const rawTitles = param('titles');
+    const titles = rawTitles.split('|').map((t: string): string => t.trim()).filter(Boolean);
+
+    const merged: Record<string, unknown> = {};
+    let nextPageid = 1;
+
+    for (const title of titles) {
+      const filename = titleToFilename(title);
+      const filePath = resolve(DATA_DIR, 'pages', filename);
+      try {
+        const data = await readJson(filePath) as { query?: { pages?: Record<string, unknown> } };
+        const pages = data.query?.pages ?? {};
+        for (const [key, page] of Object.entries(pages)) {
+          merged[key] = page;
+        }
+      } catch {
+        // Title not found: return a missing page entry
+        const missingId = (-nextPageid).toString();
+        nextPageid++;
+        merged[missingId] = { pageid: -nextPageid, ns: 0, title, missing: '' };
+      }
+    }
+
+    res.writeHead(200);
+    res.end(JSON.stringify({ query: { pages: merged } }));
+    return;
+  }
+
+  res.writeHead(400);
+  res.end(JSON.stringify({ error: { code: 'unknown_query', info: `Unknown list/prop combination` } }));
+}
+
+export async function startWikiFixtureServer(): Promise<WikiFixtureServerInterface> {
+  return new Promise<WikiFixtureServerInterface>((resolveP, rejectP) => {
+    const server = createServer((req: IncomingMessage, res: ServerResponse): void => {
+      handleRequest(req, res).catch((err: unknown): void => {
+        res.writeHead(500);
+        res.end(JSON.stringify({ error: String(err) }));
+      });
+    });
+
+    server.once('error', rejectP);
+
+    // Bind to port 0 to let the OS assign a free port
+    server.listen(0, '127.0.0.1', (): void => {
+      const addr = server.address();
+      if (addr === null || typeof addr === 'string') {
+        rejectP(new Error('Unexpected server address type'));
+        return;
+      }
+      const port    = addr.port;
+      const baseUrl = `http://127.0.0.1:${port.toString()}`;
+
+      resolveP({
+        port,
+        baseUrl,
+        close(): Promise<void> {
+          return new Promise<void>((res2, rej2): void => {
+            server.close((err: Error | undefined): void => {
+              if (err !== undefined) rej2(err);
+              else res2();
+            });
+          });
+        },
+      });
+    });
+  });
+}

--- a/tests/e2e/wiki-docs.test.ts
+++ b/tests/e2e/wiki-docs.test.ts
@@ -1,0 +1,143 @@
+// wiki-docs e2e test — MediaWiki scraper against the local fixture server.
+// Uses no external network; the fixture server serves pre-built JSON from
+// tests/e2e/fixtures/wiki/data/
+//
+// Run locally:
+//   npm run test:e2e -- --test-name-pattern='wiki-docs'
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFile, mkdir } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { MediaWikiScraper } from '../../src/scrapers/MediaWikiScraper.js';
+import { Pipeline } from '../../src/pipeline/Pipeline.js';
+import { PipelineState } from '../../src/registry/PipelineState.js';
+import { TaskRegistry } from '../../src/registry/TaskRegistry.js';
+import type { PipelineStateInterface } from '../../src/types/PipelineState.js';
+import type { WikiFixtureServerInterface } from './fixtures/wiki/server.js';
+import { startWikiFixtureServer } from './fixtures/wiki/server.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_DIR   = resolve(__dirname, '../../examples/wiki-docs/output');
+
+const EXPECTED_COMPONENTS = ['Pipeline', 'HtmlScraper', 'MediaWikiScraper', 'LinkLister', 'TaskRegistry'];
+
+interface RipperoniComponentOutput {
+  _type: 'ripperoni_component';
+  name: string;
+  kind: string;
+  since: string;
+  description: string;
+  source: string;
+}
+
+describe('wiki-docs e2e — MediaWiki scraper against fixture server', () => {
+  let fixtureServer: WikiFixtureServerInterface;
+
+  before(async () => {
+    fixtureServer = await startWikiFixtureServer();
+
+    // Load the example plugin — it self-registers `wiki-docs:parse`
+    TaskRegistry.reset();
+    await import('../../examples/wiki-docs/plugin.js');
+
+    await mkdir(OUT_DIR, { recursive: true });
+  });
+
+  after(async () => {
+    await fixtureServer.close();
+    TaskRegistry.reset();
+  });
+
+  it('fetches category members from fixture server and returns 5 components', async () => {
+    const scraper = await MediaWikiScraper.create({
+      apiUrl:      `${fixtureServer.baseUrl}/w/api.php`,
+      rateLimitMs: 0,
+    });
+
+    const members = await scraper.fetchCategory('Core Components');
+    assert.equal(members.length, 5, `expected 5 category members, got ${members.length.toString()}`);
+
+    for (const title of EXPECTED_COMPONENTS) {
+      assert.ok(
+        members.some((m) => m.title === title),
+        `expected member "${title}" in category response`,
+      );
+    }
+  });
+
+  it('scrapes all 5 components through the wiki-docs:parse pipeline', async () => {
+    const scraper = await MediaWikiScraper.create({
+      apiUrl:      `${fixtureServer.baseUrl}/w/api.php`,
+      rateLimitMs: 0,
+    });
+
+    const members = await scraper.fetchCategory('Core Components');
+    const titles  = members.map((m) => m.title);
+    const pages   = await scraper.fetchPagesBatch(titles);
+
+    assert.equal(pages.length, 5, `expected 5 pages fetched, got ${pages.length.toString()}`);
+
+    const parseTask = TaskRegistry.get('wiki-docs:parse');
+    const outputs: RipperoniComponentOutput[] = [];
+
+    for (const page of pages) {
+      const state = PipelineState.fromWikiPage('ripperoni-wiki', page);
+      const pipeline = Pipeline.create<PipelineStateInterface>({ name: 'wiki-docs-e2e' });
+      pipeline.addTask(parseTask);
+      await pipeline.execute(state);
+
+      assert.ok(state.output !== null, `expected output for "${page.title}", got null`);
+      const output = state.output as Record<string, unknown>;
+      assert.equal(output['_type'], 'ripperoni_component',
+        `expected _type=ripperoni_component for "${page.title}", got "${String(output['_type'])}"`);
+
+      outputs.push(state.output as RipperoniComponentOutput);
+    }
+
+    assert.equal(outputs.length, 5, 'expected 5 ripperoni_component outputs');
+
+    process.stdout.write(`\n  wiki-docs: extracted ${outputs.length.toString()} components from fixture server\n`);
+    for (const c of outputs) {
+      process.stdout.write(`    • ${c.name.padEnd(20)} kind=${c.kind.padEnd(8)} since=${c.since}\n`);
+    }
+
+    // Write output files
+    for (const c of outputs) {
+      const slug     = c.name.toLowerCase();
+      const outPath  = resolve(OUT_DIR, `${slug}.json`);
+      await writeFile(outPath, JSON.stringify(c, null, 2));
+    }
+
+    process.stdout.write(`  wrote ${outputs.length.toString()} JSON files to ${OUT_DIR}\n`);
+  });
+
+  it('all 5 outputs have required ripperoni_component fields', async () => {
+    const scraper = await MediaWikiScraper.create({
+      apiUrl:      `${fixtureServer.baseUrl}/w/api.php`,
+      rateLimitMs: 0,
+    });
+
+    const members = await scraper.fetchCategory('Core Components');
+    const pages   = await scraper.fetchPagesBatch(members.map((m) => m.title));
+    const parseTask = TaskRegistry.get('wiki-docs:parse');
+
+    for (const page of pages) {
+      const state = PipelineState.fromWikiPage('ripperoni-wiki', page);
+      const pipeline = Pipeline.create<PipelineStateInterface>({ name: 'wiki-docs-fields' });
+      pipeline.addTask(parseTask);
+      await pipeline.execute(state);
+
+      const c = state.output as RipperoniComponentOutput | null;
+      assert.ok(c !== null, `"${page.title}" produced null output`);
+      assert.equal(c._type, 'ripperoni_component');
+      assert.ok(c.name.length > 0,        `"${page.title}": name is empty`);
+      assert.ok(c.kind.length > 0,        `"${page.title}": kind is empty`);
+      assert.ok(c.since.length > 0,       `"${page.title}": since is empty`);
+      assert.ok(c.description.length > 0, `"${page.title}": description is empty`);
+      assert.ok(c.source.length > 0,      `"${page.title}": source is empty`);
+    }
+  });
+});

--- a/tsconfig.plugins.json
+++ b/tsconfig.plugins.json
@@ -8,6 +8,6 @@
     "declaration": false,
     "noEmit": false
   },
-  "include": ["plugins/**/*.ts"],
+  "include": ["plugins/**/*.ts", "examples/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

The documentation pages ARE the HTML fixture. No separate fixture HTML files — the e2e tests prove the scraper works by scraping ripperoni's own published docs. Wiki fixture mirrors the same content in MediaWiki format, served by a local fixture server.

## Type of Change
- [x] Feature (new functionality)
- [ ] Bug fix (non-breaking fix)
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring
- [ ] Chore

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

## Checklist
- [x] Code follows project conventions (typecheck + lint clean)
- [ ] CHANGELOG.md updated under `## [Unreleased]`
- [x] No real target names introduced (target-neutrality gate passes)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] All tests pass

## Related Issues
<!-- Fixes #123 -->

May the Machine Spirit keep our documentation and tests in perpetual alignment.