### PR TITLE
fix(pages): enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,6 +2,7 @@ name: Deploy docs to GitHub Pages
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 permissions:
   pages: write
   id-token: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-beta.5] - 2026-04-30
+
+### Fixed
+- GitHub Pages deployment: enable the Pages site via API and add `workflow_dispatch` trigger so deployments can be manually re-run
+
 ## [2.0.0-beta.4] - 2026-04-30
 
 ### Changed
@@ -78,7 +83,8 @@ extraction pipeline. Plugin source files ship separately as examples in v1.
 ### Security
 - `npm audit --omit=dev` exits 0; all production dependency advisories resolved
 
-[Unreleased]: https://github.com/Studnicky/PathRipper/compare/v2.0.0-beta.4...HEAD
+[Unreleased]: https://github.com/Studnicky/PathRipper/compare/v2.0.0-beta.5...HEAD
+[2.0.0-beta.5]: https://github.com/Studnicky/PathRipper/compare/v2.0.0-beta.4...v2.0.0-beta.5
 [2.0.0-beta.4]: https://github.com/Studnicky/PathRipper/compare/v2.0.0-beta.3...v2.0.0-beta.4
 [2.0.0-beta.3]: https://github.com/Studnicky/PathRipper/compare/v2.0.0-beta.2...v2.0.0-beta.3
 [2.0.0-beta.2]: https://github.com/Studnicky/PathRipper/compare/v2.0.0-beta.1...v2.0.0-beta.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripperoni",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "Configurable web scraper — pluggable pipeline tasks, HTML and MediaWiki modes, recursive link crawler.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

GitHub Pages was never enabled on the repo — failing with "Not Found" on every push to master since beta.2. Enabled via API (`build_type=workflow`). Added `workflow_dispatch` so deploys can be triggered without a dummy push.

## Type of Change
- [ ] Feature (new functionality)
- [x] Bug fix (non-breaking fix)
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed

## Checklist
- [x] Code follows project conventions (typecheck + lint clean)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] No real target names introduced (target-neutrality gate passes)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] All tests pass

## Related Issues

Fixes Pages deployment failing since beta.2.

The Omnissiah's documentation shall now propagate to all nodes.
