### PR TITLE
feat(docs): icon-extracted palette, TORUS backronym

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-04-30
+
+### Changed
+- All "Torus" references replaced with **TORUS** *(Topological Orchestration Runtime for Unified Streaming)* — described as an upcoming streaming DAG orchestration tool currently under development
+- Docs color palette rebuilt from pixel-accurate extraction of the ripperoni icon: `--meat` `#f05870`, `--meat-deep` `#c82840`, `--fat` `#f6d1cf`, `--blue` `#2090e0`, `--blue-deep` `#103050`, `--ink` `#2e0104`
+- Background surfaces, borders, code blocks, and Mermaid diagrams all updated to the extracted palette
+- Foreground text warm-shifted to echo the fat marbling tone (`#ede0df`)
+
 ## [2.0.1] - 2026-04-30
 
 ### Fixed
@@ -113,7 +121,8 @@ extraction pipeline. Plugin source files ship separately as examples in v1.
 ### Security
 - `npm audit --omit=dev` exits 0; all production dependency advisories resolved
 
-[Unreleased]: https://github.com/Studnicky/PathRipper/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/Studnicky/PathRipper/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/Studnicky/PathRipper/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Studnicky/PathRipper/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Studnicky/PathRipper/compare/v2.0.0-beta.5...v2.0.0
 [2.0.0-beta.5]: https://github.com/Studnicky/PathRipper/compare/v2.0.0-beta.4...v2.0.0-beta.5

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Web ingestion engine. Point it at a wiki, a site, or a list of URLs. It slices through everything, one page at a time, and hands you the meat.
 
-Evolved from [PathRipper](https://github.com/Studnicky/PathRipper) (2019). HTTP machinery ported from [Torus](https://github.com/Studnicky/torus).
+Evolved from [PathRipper](https://github.com/Studnicky/PathRipper) (2019). HTTP machinery ported from TORUS (Topological Orchestration Runtime for Unified Streaming), an upcoming streaming DAG orchestration tool currently under development.
 
 **[Documentation](https://studnicky.github.io/PathRipper/)** · **[Architecture](https://studnicky.github.io/PathRipper/architecture.html)** · **[Roadmap](https://studnicky.github.io/PathRipper/roadmap.html)** · **[Releases](https://github.com/Studnicky/PathRipper/releases)**
 

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -48,10 +48,10 @@ graph TD
     RetryExecutor[modules/http/RetryExecutor] --> ErrorClassifier
     RateLimiter[modules/http/RateLimiter] -.wraps.-> bottleneck
 
-    style Pipeline fill:#1a1a1a,stroke:#c8284a
-    style ErrorClassifier fill:#1a1a1a,stroke:#c8284a
-    style RetryExecutor fill:#1a1a1a,stroke:#c8284a
-    style RateLimiter fill:#1a1a1a,stroke:#c8284a
+    style Pipeline fill:#180808,stroke:#f05870
+    style ErrorClassifier fill:#180808,stroke:#f05870
+    style RetryExecutor fill:#180808,stroke:#f05870
+    style RateLimiter fill:#180808,stroke:#f05870
         </div>
       </section>
 
@@ -95,7 +95,7 @@ await pipeline.execute(PipelineState.fromWikiPage('my-target', page));</code></p
       <section id="http-layer" data-component="http">
         <h2>HTTP machinery</h2>
         <p class="summary">Three composable classes — RateLimiter, RetryExecutor, and ErrorClassifier — form the HTTP stack, each injected independently.</p>
-        <p>Three classes form the HTTP stack, ported from <a href="https://github.com/Studnicky/torus">Torus</a>. They're independent of each other and compose by injection.</p>
+        <p>Three classes form the HTTP stack, ported from TORUS (Topological Orchestration Runtime for Unified Streaming), an upcoming streaming DAG orchestration tool currently under development. They're independent of each other and compose by injection.</p>
 
         <div class="mermaid">
 graph LR
@@ -177,13 +177,13 @@ graph LR
 
       <section id="source-map" data-component="source-map">
         <h2>Source map</h2>
-        <p class="summary">Complete index of every source file, its exported symbols, and the PathRipper or Torus module it was ported from.</p>
+        <p class="summary">Complete index of every source file, its exported symbols, and the PathRipper or TORUS module it was ported from.</p>
         <table>
           <thead><tr><th>File</th><th>Exports</th><th>Ported from</th></tr></thead>
           <tbody>
             <tr><td><code>src/pipeline/Pipeline.ts</code></td><td><code>Pipeline&lt;TState&gt;</code></td><td>PathRipper <code>Transformer</code></td></tr>
-            <tr><td><code>src/modules/http/ErrorClassifier.ts</code></td><td><code>ErrorClassifier</code>, <code>ErrorCategory</code></td><td>Torus <code>errorClassifier.ts</code></td></tr>
-            <tr><td><code>src/modules/http/RetryExecutor.ts</code></td><td><code>RetryExecutor</code></td><td>Torus <code>RetryPolicyNode</code></td></tr>
+            <tr><td><code>src/modules/http/ErrorClassifier.ts</code></td><td><code>ErrorClassifier</code>, <code>ErrorCategory</code></td><td>TORUS <code>errorClassifier.ts</code></td></tr>
+            <tr><td><code>src/modules/http/RetryExecutor.ts</code></td><td><code>RetryExecutor</code></td><td>TORUS <code>RetryPolicyNode</code></td></tr>
             <tr><td><code>src/modules/http/RateLimiter.ts</code></td><td><code>RateLimiter</code></td><td>New — wraps <code>bottleneck</code></td></tr>
             <tr><td><code>src/modules/logger/Logger.ts</code></td><td><code>Logger</code></td><td>Torreya <code>@torreya/logger</code></td></tr>
             <tr><td><code>src/scrapers/HtmlScraper.ts</code></td><td><code>HtmlScraper</code></td><td>PathRipper <code>fetchPage</code>, cheerio replaces JSDOM</td></tr>
@@ -207,7 +207,7 @@ graph LR
 
   <script src="assets/sidebar.js"></script>
   <script>
-    mermaid.initialize({ startOnLoad: true, theme: 'dark', themeVariables: { primaryColor: '#1a1a1a', primaryTextColor: '#e8e8e8', primaryBorderColor: '#c8284a', lineColor: '#888', background: '#0d0d0d' } });
+    mermaid.initialize({ startOnLoad: true, theme: 'dark', themeVariables: { primaryColor: '#180808', primaryTextColor: '#f6d1cf', primaryBorderColor: '#f05870', lineColor: '#2090e0', secondaryColor: '#100606', tertiaryColor: '#103050', background: '#0d0d0d', nodeBorder: '#c82840', clusterBkg: '#180808', titleColor: '#f6d1cf', edgeLabelBackground: '#180808', actorBkg: '#180808', actorBorder: '#f05870', actorTextColor: '#f6d1cf', noteBkgColor: '#180808', noteTextColor: '#f6d1cf' } });
     initSidebar([
       { href: '#module-graph', label: 'Module graph' },
       { href: '#pipeline',     label: 'Pipeline pattern' },

--- a/docs/assets/sidebar.css
+++ b/docs/assets/sidebar.css
@@ -1,19 +1,37 @@
-/* ─── Theme — derived from the salami icon palette ──────────────────────────
-   Source of truth. All pages import this file. Do not redeclare :root elsewhere.
+/* ─── Palette — extracted from the ripperoni icon ────────────────────────────
+   Pixel-accurate colors sampled from ripperoni-transparent-no-star.png.
+   Source of truth. Do not redeclare :root on any page.
+
+   --meat        #f05870   dominant body (7.9% of pixels) — primary accent
+   --meat-deep   #c82840   deepest shadows (1.8%)          — borders, hover
+   --fat         #f6d1cf   light marbling (9.7%)           — soft text/code
+   --blue        #2090e0   splash dots                     — minor accent
+   --blue-deep   #103050   dark blue shadow                — subtle depth
+   --ink         #2e0104   near-black outline              — darkest surfaces
    ──────────────────────────────────────────────────────────────────────────── */
 :root {
-  --bg:           #0d0d0d;
-  --fg:           #e8e8e8;
-  --accent:       #c8284a;   /* salami crimson */
-  --accent-soft:  #f08090;   /* fat/marbling pink */
-  --splash:       #4a90e2;   /* blue accent from the icon splashes */
-  --muted:        #888;
-  --card:         #1a1a1a;
-  --border:       #1e1e1e;
-  --border-hi:    #2a2a2a;
-  --code-bg:      #1f1f1f;
-  --pre-bg:       #141414;
-  --sidebar-w:    210px;
+  /* Extracted palette */
+  --meat:        #f05870;
+  --meat-deep:   #c82840;
+  --fat:         #f6d1cf;
+  --blue:        #2090e0;
+  --blue-deep:   #103050;
+  --ink:         #2e0104;
+
+  /* Semantic assignments */
+  --bg:          #0d0d0d;
+  --fg:          #ede0df;
+  --accent:      var(--meat);
+  --accent-deep: var(--meat-deep);
+  --accent-soft: var(--fat);
+  --splash:      var(--blue);
+  --muted:       #9a8080;
+  --card:        #180808;
+  --border:      #2a1010;
+  --border-hi:   #3d1818;
+  --code-bg:     #1a0808;
+  --pre-bg:      #100606;
+  --sidebar-w:   210px;
 }
 
 /* ─── Reset ──────────────────────────────────────────────────────────────── */
@@ -22,24 +40,26 @@
 /* ─── Base ───────────────────────────────────────────────────────────────── */
 body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro", "Helvetica Neue", sans-serif; background: var(--bg); color: var(--fg); line-height: 1.6; }
 a { color: var(--accent); text-decoration: none; }
-a:hover { text-decoration: underline; }
+a:hover { color: var(--meat-deep); text-decoration: underline; }
 code { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 0.9em; background: var(--code-bg); color: var(--accent-soft); padding: 0.1rem 0.4rem; border-radius: 4px; }
-pre { background: var(--pre-bg); border: 1px solid #262626; border-radius: 8px; padding: 1.1rem 1.25rem; overflow-x: auto; margin: 0.9rem 0 1.1rem; }
-pre code { background: none; padding: 0; font-size: 0.85rem; color: #d4d4d4; }
+pre { background: var(--pre-bg); border: 1px solid #2a1010; border-radius: 8px; padding: 1.1rem 1.25rem; overflow-x: auto; margin: 0.9rem 0 1.1rem; }
+pre code { background: none; padding: 0; font-size: 0.85rem; color: #ddd0cf; }
+strong { color: var(--fg); }
 
 /* ─── Layout ─────────────────────────────────────────────────────────────── */
 .layout { display: flex; max-width: 980px; margin: 0 auto; padding: 0 1.5rem; gap: 3rem; }
 .main { flex: 1; min-width: 0; padding: 3rem 0 3rem 3rem; border-left: 1px solid var(--border); }
 .intro { margin-bottom: 2.5rem; }
-.intro p { color: #ccc; margin-bottom: 0.7rem; }
+.intro p { color: #ccc0bf; margin-bottom: 0.7rem; }
 .intro p:last-child { margin-bottom: 0; }
+.intro em { color: var(--fat); font-style: italic; }
 
 /* ─── Sections ───────────────────────────────────────────────────────────── */
 section { margin: 0 0 2.5rem; scroll-margin-top: 2rem; }
 section:last-child { margin-bottom: 0; }
-section h2 { font-size: 1.25rem; font-weight: 600; margin-bottom: 0.75rem; border-bottom: 1px solid var(--border-hi); padding-bottom: 0.4rem; }
+section h2 { font-size: 1.25rem; font-weight: 600; margin-bottom: 0.75rem; border-bottom: 1px solid var(--border-hi); padding-bottom: 0.4rem; color: var(--fg); }
 section h3 { font-size: 1rem; font-weight: 600; margin: 1.25rem 0 0.4rem; color: var(--accent-soft); }
-section p, section li { color: #ccc; }
+section p, section li { color: #ccc0bf; }
 section p { margin-bottom: 0.7rem; }
 section p:last-child { margin-bottom: 0; }
 ul { list-style: none; padding: 0; }
@@ -49,8 +69,9 @@ ul li::before { content: "/ "; color: var(--accent); }
 /* ─── Tables ─────────────────────────────────────────────────────────────── */
 table { width: 100%; border-collapse: collapse; margin: 0.75rem 0 1rem; font-size: 0.88rem; }
 th { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--border-hi); color: var(--muted); font-weight: 600; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.05em; }
-td { padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--border); color: #ccc; vertical-align: top; }
+td { padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--border); color: #ccc0bf; vertical-align: top; }
 tr:last-child td { border-bottom: none; }
+tr:hover td { background: #180a0a; }
 td code { font-size: 0.82rem; }
 
 /* ─── Footer ─────────────────────────────────────────────────────────────── */
@@ -71,19 +92,19 @@ footer p + p { margin-top: 0.3rem; }
 .sidebar { width: var(--sidebar-w); flex-shrink: 0; padding: 3rem 0; }
 .sidebar-inner { position: sticky; top: 2rem; }
 .app-icon { width: 100%; display: block; margin-bottom: 0.75rem; object-fit: contain; }
-.sidebar h1 { font-size: 1.4rem; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 0.2rem; }
+.sidebar h1 { font-size: 1.4rem; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 0.2rem; color: var(--fg); }
 .sidebar .tagline { font-size: 0.8rem; color: var(--muted); margin-bottom: 1.25rem; line-height: 1.4; }
-.badge { display: inline-block; background: #1f1f1f; color: var(--muted); font-size: 0.72rem; font-weight: 500; padding: 0.2rem 0.6rem; border-radius: 999px; border: 1px solid #333; margin-bottom: 1.5rem; }
-.gh-btn { display: block; background: var(--accent); color: #fff; font-weight: 600; padding: 0.65rem 1rem; border-radius: 8px; font-size: 0.9rem; text-align: center; margin-bottom: 1.75rem; }
-.gh-btn:hover { text-decoration: none; opacity: 0.88; }
+.badge { display: inline-block; background: var(--card); color: var(--fat); font-size: 0.72rem; font-weight: 500; padding: 0.2rem 0.6rem; border-radius: 999px; border: 1px solid var(--border-hi); margin-bottom: 1.5rem; }
+.gh-btn { display: block; background: var(--meat-deep); color: #fff; font-weight: 600; padding: 0.65rem 1rem; border-radius: 8px; font-size: 0.9rem; text-align: center; margin-bottom: 1.75rem; border: 1px solid var(--meat); }
+.gh-btn:hover { background: var(--meat); text-decoration: none; }
 .toc-label, .pages-label { font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); margin-bottom: 0.5rem; display: block; }
 .toc { list-style: none; margin-bottom: 1.75rem; }
 .toc li { padding: 0.15rem 0; }
 .toc li::before { content: none; }
-.toc a { font-size: 0.82rem; color: #aaa; }
+.toc a { font-size: 0.82rem; color: #a89090; }
 .toc a:hover { color: var(--accent); text-decoration: none; }
 .page-links { list-style: none; }
 .page-links li { padding: 0.15rem 0; }
 .page-links li::before { content: none; }
-.page-links a { font-size: 0.82rem; color: #aaa; }
+.page-links a { font-size: 0.82rem; color: #a89090; }
 .page-links a:hover { color: var(--accent); text-decoration: none; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
       <div class="intro">
         <p>Point it at a wiki, a site, or a list of URLs. It slices through everything, one page at a time, and hands you the meat. The domain-specific bits are your problem — write a plugin, register it, and Ripperoni will run it against every page it finds.</p>
         <p>The core is a typed middleware pipeline: small task functions chain with <code>next()</code>, each one narrowing the raw page into structured output. Retry logic, rate limiting, and error classification are built in. The engine doesn't know what you're scraping and it doesn't care. <em>That's the point.</em></p>
-        <p>Grew out of <a href="https://github.com/Studnicky/PathRipper">PathRipper</a> (2019). HTTP machinery ported from <a href="https://github.com/Studnicky/torus">Torus</a>. The rest is new. Now available with 100% more salami iconography.</p>
+        <p>Grew out of <a href="https://github.com/Studnicky/PathRipper">PathRipper</a> (2019). HTTP machinery ported from TORUS (Topological Orchestration Runtime for Unified Streaming), an upcoming streaming DAG orchestration tool currently under development. The rest is new. Now available with 100% more salami iconography.</p>
       </div>
 
       <section id="features">
@@ -48,11 +48,11 @@
           </div>
           <div class="feature">
             <h3>Retry + Backoff</h3>
-            <p>Ported from Torus's <code>RetryPolicyNode</code>. Exponential backoff with ±10% decorrelated jitter. Respects <code>Retry-After</code> headers. Configurable max attempts, base delay, multiplier, and ceiling.</p>
+            <p>Ported from TORUS's <code>RetryPolicyNode</code>. Exponential backoff with ±10% decorrelated jitter. Respects <code>Retry-After</code> headers. Configurable max attempts, base delay, multiplier, and ceiling.</p>
           </div>
           <div class="feature">
             <h3>Error Classification</h3>
-            <p>Ported from Torus's <code>ErrorClassifier</code>. Classifies errors as NETWORK / THROTTLED / TIMEOUT / TRANSIENT / PERMANENT / VALIDATION / RESOURCE. Only retryable categories trigger a retry.</p>
+            <p>Ported from TORUS's <code>ErrorClassifier</code>. Classifies errors as NETWORK / THROTTLED / TIMEOUT / TRANSIENT / PERMANENT / VALIDATION / RESOURCE. Only retryable categories trigger a retry.</p>
           </div>
           <div class="feature">
             <h3>Rate Limiter</h3>
@@ -209,7 +209,7 @@ TaskRegistry.register('my-target:parse', async (next, state) => {
 
       <footer>
         <p>Ripperoni v2.0.0 · TypeScript · Node 24+ · <a href="https://github.com/Studnicky/PathRipper">GitHub</a> · <a href="https://github.com/Studnicky/PathRipper/releases">Releases</a> · <a href="https://github.com/Studnicky/PathRipper/issues">Issues</a></p>
-        <p>Evolved from <a href="https://github.com/Studnicky/PathRipper">PathRipper</a> (2019). HTTP internals ported from <a href="https://github.com/Studnicky/torus">Torus</a>. Engineered with unreasonable care for a deeply optional purpose.</p>
+        <p>Evolved from <a href="https://github.com/Studnicky/PathRipper">PathRipper</a> (2019). HTTP internals ported from TORUS (Topological Orchestration Runtime for Unified Streaming), an upcoming streaming DAG orchestration tool currently under development. Engineered with unreasonable care for a deeply optional purpose.</p>
       </footer>
     </main>
   </div>

--- a/docs/plans/04-config-validation.md
+++ b/docs/plans/04-config-validation.md
@@ -23,7 +23,7 @@ all silently succeed at load time and produce confusing failures downstream
 ## Fix
 
 Add AJV-based validation in `RipperConfig.load()`.
-Follow the Torreya/Torus pattern: write the JSON Schema once, derive the TypeScript type
+Follow the Torreya/TORUS pattern: write the JSON Schema once, derive the TypeScript type
 from it with `json-schema-to-ts`, compile the AJV validator once at module load.
 
 ### Schema location

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -14,9 +14,9 @@
     .card p { font-size: 0.85rem; color: var(--muted); margin: 0 0 0.4rem; }
     .card p:last-child { margin: 0; }
     .status { display: inline-block; font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; padding: 0.15rem 0.5rem; border-radius: 999px; margin-bottom: 0.5rem; }
-    .status-live     { background: #1a3a1a; color: #6bdb6b; border: 1px solid #2a5a2a; }
-    .status-planned  { background: #2a2a1a; color: #c4b45a; border: 1px solid #4a4a2a; }
-    .status-separate { background: #1a1a3a; color: #6b7cdb; border: 1px solid #2a2a5a; }
+    .status-live     { background: #0a2010; color: #60c060; border: 1px solid #1a4a20; }
+    .status-planned  { background: #1a1008; color: var(--fat); border: 1px solid #3a2010; }
+    .status-separate { background: #080818; color: var(--blue); border: 1px solid var(--blue-deep); }
     @media (max-width: 700px) { .grid { grid-template-columns: 1fr; } }
   </style>
 </head>
@@ -35,7 +35,7 @@
           <div class="card">
             <span class="status status-live">live</span>
             <h3>TypeScript rewrite</h3>
-            <p>Full strict TypeScript from scratch. Torus tsconfig + eslint config ported directly. <code>exactOptionalPropertyTypes</code>, <code>noUncheckedIndexedAccess</code>, flat ESLint config.</p>
+            <p>Full strict TypeScript from scratch. TORUS tsconfig + eslint config ported directly. <code>exactOptionalPropertyTypes</code>, <code>noUncheckedIndexedAccess</code>, flat ESLint config.</p>
           </div>
           <div class="card">
             <span class="status status-live">live</span>
@@ -60,7 +60,7 @@
           <div class="card">
             <span class="status status-live">live</span>
             <h3>HTTP machinery</h3>
-            <p>ErrorClassifier + RetryExecutor ported from Torus. RateLimiter wrapping <code>bottleneck</code>. Retry-After header respected. Seven error categories. Exponential + jitter backoff.</p>
+            <p>ErrorClassifier + RetryExecutor ported from TORUS (Topological Orchestration Runtime for Unified Streaming). RateLimiter wrapping <code>bottleneck</code>. Retry-After header respected. Seven error categories. Exponential + jitter backoff.</p>
           </div>
           <div class="card">
             <span class="status status-live">live</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripperoni",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Configurable web scraper — pluggable pipeline tasks, HTML and MediaWiki modes, recursive link crawler.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Two changes in one pass: pixel-accurate color palette extracted from the icon, and all "Torus" references replaced with the TORUS backronym.

**Palette** — sampled directly from `ripperoni-transparent-no-star.png` (444k non-background pixels): `--meat #f05870` (dominant, 7.9%), `--meat-deep #c82840` (deepest shadow), `--fat #f6d1cf` (marbling, 9.7%), `--blue #2090e0` (splash dots), `--blue-deep #103050` (dark shadow), `--ink #2e0104` (outline). Applied to backgrounds, borders, code blocks, tables, Mermaid diagrams, and status badges. Foreground warm-shifted to `#ede0df`.

**TORUS** — all bare "Torus" mentions replaced with TORUS *(Topological Orchestration Runtime for Unified Streaming)*, described as an upcoming streaming DAG orchestration tool currently under development.

## Type of Change
- [ ] Feature (new functionality)
- [ ] Bug fix (non-breaking fix)
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring
- [ ] Chore

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed

90/90 unit tests pass. Visual inspection of all three pages.

## Checklist
- [x] Code follows project conventions (typecheck + lint clean)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] No real target names introduced (target-neutrality gate passes)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] All tests pass

## Related Issues

Closes out the branding pass. The salami speaks its own colors now.
