### PR TITLE
chore(release): 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-05-05
+
+### Added
+
+- Docs site favicon: VitePress `head` block now declares the salami logo as the page icon, parallel to Squashage.
+
+### Changed
+
+- Dependency baseline refresh:
+  - `typescript` 5.9.3 → 6.0.3
+  - `@types/node` 22.19.17 → 25.6.0
+  - `commander` 12.1.0 → 14.0.3
+  - `globals` 15.15.0 → 17.6.0
+  - `typescript-eslint` 8.59.0 → 8.59.2 (minor-and-patch group)
+  - `eslint-ecosystem` group: 2 patch updates
+- GitHub Actions baseline:
+  - `actions/setup-node` 4 → 6
+
+
 ### Added
 
 - Docs site favicon — VitePress `head` block now includes `<link rel="icon" href="/Ripperoni/ripperoni.png">`. Tab icon now matches the navbar logo, parallel to Squashage's setup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Docs site favicon — VitePress `head` block now includes `<link rel="icon" href="/Ripperoni/ripperoni.png">`. Tab icon now matches the navbar logo, parallel to Squashage's setup.
+
 ## [2.2.2] - 2026-05-06
 
 ### Fixed

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -34,6 +34,9 @@ export default defineConfig({
   appearance: themeConfig.appearance,
   base: '/Ripperoni/',
   description: 'Web ingestion engine — slices wikis, sites, and URL lists into JSON records. Feed them into Squashage for graph reconstitution.',
+  head: [
+    ['link', { rel: 'icon', type: 'image/png', href: '/Ripperoni/ripperoni.png' }],
+  ],
   srcDir: '.',
   srcExclude: ['plans/**', 'plans/*.md'],
   themeConfig: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ripperoni",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ripperoni",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripperoni",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Web ingestion engine — slices wikis, sites, and URL lists into JSON records, one page at a time. Pairs with Squashage for RDF graph reconstitution.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Minor release v2.3.0 — dependency baseline refresh (TS 5.9→6.0, @types/node 22→25, commander 12→14, globals 15→17, ecosystem patches), `actions/setup-node` 4→6, and the `/Ripperoni/ripperoni.png` favicon link in the docs site.

## Type of Change
- [ ] Feature (new functionality)
- [x] Breaking change (TypeScript major bump)
- [x] Bug fix (favicon)
- [x] Documentation
- [ ] Refactoring
- [x] Chore (release)

## Testing
- [x] Unit tests pass on develop
- [x] CI green across the matrix

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Documentation updated (CHANGELOG.md 2.3.0 entry)
- [x] All tests pass

## Related Issues
Bundles dependabot PRs #29, #30, #32, #36, #37, #38, #39 plus favicon PR #41 into v2.3.0. Closes #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
