### PR TITLE
chore(docs): replace em-dashes with plain punctuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Em-dashes (`—`) replaced with plain punctuation (`: ` for list/definition items, `; ` for clause joins, `, ` mid-sentence) across `README.md`, `docs/**/*.md`, `package.json`, and `docs/.vitepress/config.ts`. ~95 occurrences total. CHANGELOG history left untouched.
+
 ### Added
 
 - Mechanism-depth expansions across user-facing docs (architecture, pipeline, cache, scrapers, configuration, crawler, mediawiki, plugins) following the yamete-fidelity bar: problem framing, state machines, error propagation, parameter rationale, edge cases.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm run build
 ## Quickstart
 
 ```bash
-# Scrape a MediaWiki target — one category
+# Scrape a MediaWiki target: one category
 ripperoni scrape \
   --target <your-wiki-target> \
   --category "Example Category Name" \
@@ -55,7 +55,7 @@ ripperoni crawl \
   --delimiter "category"
 ```
 
-Copy `ripperoni.config.example.json` to `ripperoni.config.json` and edit. The unprefixed file is gitignored — it holds your real targets.
+Copy `ripperoni.config.example.json` to `ripperoni.config.json` and edit. The unprefixed file is gitignored; it holds your real targets.
 
 ## Scripts
 
@@ -93,7 +93,7 @@ All scraper targets live in `ripperoni.config.json` (the project itself names no
 }
 ```
 
-`categories` is optional — omit it to scrape every article in the wiki via the allpages API. `tasks` points at user-written parse plugins that run through the pipeline before each page is written.
+`categories` is optional; omit it to scrape every article in the wiki via the allpages API. `tasks` points at user-written parse plugins that run through the pipeline before each page is written.
 
 The config is validated on load against the internal JSON Schema; malformed files fail fast with a precise field-path error message.
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -33,7 +33,7 @@ const sidebar = [
 export default defineConfig({
   appearance: themeConfig.appearance,
   base: '/Ripperoni/',
-  description: 'Web ingestion engine — slices wikis, sites, and URL lists into JSON records. Feed them into Squashage for graph reconstitution.',
+  description: 'Web ingestion engine; slices wikis, sites, and URL lists into JSON records. Feed them into Squashage for graph reconstitution.',
   head: [
     ['link', { rel: 'icon', type: 'image/png', href: '/Ripperoni/ripperoni.png' }],
   ],

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Three independent concerns — **pipeline**, **HTTP machinery**, and **scrapers** — compose to produce a scraping job. Nothing in the pipeline knows about HTTP. Nothing in the HTTP layer knows about MediaWiki. The scraper classes are pure data accessors that return typed results.
+Three independent concerns (**pipeline**, **HTTP machinery**, and **scrapers**) compose to produce a scraping job. Nothing in the pipeline knows about HTTP. Nothing in the HTTP layer knows about MediaWiki. The scraper classes are pure data accessors that return typed results.
 
 ## Module graph
 
@@ -85,19 +85,19 @@ await pipeline.execute(PipelineState.fromWikiPage('my-target', page));
 type TaskFnType<TState> = (next: NextFnType, state: TState) => Promise<void>
 ```
 
-`TState` must extend `Record<string, unknown>`. Tasks mutate state directly — the pipeline passes the same reference through the chain.
+`TState` must extend `Record<string, unknown>`. Tasks mutate state directly; the pipeline passes the same reference through the chain.
 
 Why this matters: If a task decides to bail out (malformed HTML, missing required field), it skips `await next()` and the write task never runs. You don't need error handling middleware; you just don't call `next()`. This is simpler than try/catch chains and keeps the control flow local to each task.
 
 ## HTTP machinery
 
-Three composable classes — `RateLimiter`, `RetryExecutor`, and `ErrorClassifier` — form the HTTP stack, each injected independently.
+Three composable classes (`RateLimiter`, `RetryExecutor`, and `ErrorClassifier`) form the HTTP stack, each injected independently.
 
 Problem being solved: HTTP is unreliable. Networks fail. Servers get overloaded and 429. Caches go stale. When Ripperoni fetches a page, it needs to retry transient errors but give up on permanent ones, respect `Retry-After` headers, and throttle to avoid hammering the target server. The three-class stack keeps these concerns separate so you can swap implementations or compose them differently in tests.
 
 Error propagation rules: An error enters `ErrorClassifier` which examines the error object or HTTP status code. If the classifier says it's retryable (`NETWORK`, `TIMEOUT`, `THROTTLED`, `TRANSIENT`), the error goes back to `RetryExecutor` which waits and tries again. If the classifier says it's permanent (`PERMANENT`, `VALIDATION`, `RESOURCE`), the error is thrown immediately. A 404 is permanent (throw immediately). A 500 is transient (retry). A 429 is throttled (retry with `Retry-After` delay).
 
-Cache and retry interaction: The cache sits upstream of this stack. A cache hit bypasses the entire HTTP machinery — the cached body is returned directly to the pipeline. A cache miss enters the HTTP stack: rate limiter makes you wait, then RetryExecutor calls fetch, then ErrorClassifier decides if we retry. On success, the response is cached. So the first fetch of a URL pays the full HTTP + retry cost; the second fetch hits cache and costs almost nothing.
+Cache and retry interaction: The cache sits upstream of this stack. A cache hit bypasses the entire HTTP machinery; the cached body is returned directly to the pipeline. A cache miss enters the HTTP stack: rate limiter makes you wait, then RetryExecutor calls fetch, then ErrorClassifier decides if we retry. On success, the response is cached. So the first fetch of a URL pays the full HTTP + retry cost; the second fetch hits cache and costs almost nothing.
 
 ```mermaid
 graph LR
@@ -148,7 +148,7 @@ Backoff formula: `delay = min(baseDelayMs * 2^attempt, maxDelayMs) ± jitter`. F
 
 Token-bucket backed by `bottleneck`. Factory methods: `RateLimiter.perSecond(n)` for throughput-based limits, `RateLimiter.withDelay(ms)` for fixed-gap limits. Used by every scraper and crawler.
 
-Rate limiting applies per request. If you set `rateLimitMs: 1000`, every fetch is at least 1000ms apart. If you set `jitterMs: 250`, an additional 0–250ms random delay is added per request. Jitter prevents synchronized bursts when multiple tasks start together. The limiter enforces this before the HTTP call enters the retry executor, so rate limiting happens even on retries — each retry attempt waits its own `minTime` before executing.
+Rate limiting applies per request. If you set `rateLimitMs: 1000`, every fetch is at least 1000ms apart. If you set `jitterMs: 250`, an additional 0–250ms random delay is added per request. Jitter prevents synchronized bursts when multiple tasks start together. The limiter enforces this before the HTTP call enters the retry executor, so rate limiting happens even on retries; each retry attempt waits its own `minTime` before executing.
 
 ## Scrapers
 
@@ -156,16 +156,16 @@ Pure data accessors for HTML (via cheerio) and MediaWiki (via native fetch) that
 
 ### HtmlScraper
 
-Native `fetch` + `cheerio`. Returns `ScrapedPageInterface { url, $, html }`. The `$` field is a live `CheerioAPI` handle — use it exactly as you'd use jQuery on a DOM. No browser engine, no JavaScript execution. For JS-rendered pages, swap the fetch call for a headless driver (Playwright, Puppeteer) and feed the HTML to `cheerio.load()`.
+Native `fetch` + `cheerio`. Returns `ScrapedPageInterface { url, $, html }`. The `$` field is a live `CheerioAPI` handle; use it exactly as you'd use jQuery on a DOM. No browser engine, no JavaScript execution. For JS-rendered pages, swap the fetch call for a headless driver (Playwright, Puppeteer) and feed the HTML to `cheerio.load()`.
 
 ### MediaWikiScraper
 
-Direct `fetch()` calls to the MediaWiki JSON API — no mwn or axios layer. Four operations:
+Direct `fetch()` calls to the MediaWiki JSON API; no mwn or axios layer. Four operations:
 
-- `fetchPage(title)` — single page wikitext
-- `fetchPagesBatch(titles)` — up to 50 pages per API request
-- `fetchCategory(name)` — paginated category members list
-- `fetchAllPages()` — enumerates every article in main namespace via `action=query&list=allpages`
+- `fetchPage(title)`: single page wikitext
+- `fetchPagesBatch(titles)`: up to 50 pages per API request
+- `fetchCategory(name)`: paginated category members list
+- `fetchAllPages()`: enumerates every article in main namespace via `action=query&list=allpages`
 
 The `ScrapeOrchestrator` selects from three modes: explicit `--category` flag → single category; `categories[]` in config → iterate and deduplicate; no categories → `fetchAllPages()`. Rate limiting and jitter applied per-request.
 
@@ -185,7 +185,7 @@ Three regexes control behavior:
 | `delimiter` | Links that match are traversed (followed). Links that don't are ignored entirely. |
 | `target` | Links that match the delimiter AND this pattern are collected as results. Others are traversed but not returned. |
 
-Visited URLs are tracked in a `Set`. All traversals run concurrently via `Promise.all` at each level. Results are deduplicated and sorted with a numeric-aware collator — so `Item-10` sorts after `Item-9`, not between `Item-1` and `Item-2`.
+Visited URLs are tracked in a `Set`. All traversals run concurrently via `Promise.all` at each level. Results are deduplicated and sorted with a numeric-aware collator; so `Item-10` sorts after `Item-9`, not between `Item-1` and `Item-2`.
 
 ## Source map
 
@@ -196,14 +196,14 @@ Complete index of every source file, its exported symbols, and the PathRipper or
 | `src/pipeline/Pipeline.ts` | `Pipeline<TState>` | PathRipper `Transformer` |
 | `src/modules/http/ErrorClassifier.ts` | `ErrorClassifier`, `ErrorCategory` | TORUS `errorClassifier.ts` |
 | `src/modules/http/RetryExecutor.ts` | `RetryExecutor` | TORUS `RetryPolicyNode` |
-| `src/modules/http/RateLimiter.ts` | `RateLimiter` | New — wraps `bottleneck` |
+| `src/modules/http/RateLimiter.ts` | `RateLimiter` | New: wraps `bottleneck` |
 | `src/modules/logger/Logger.ts` | `Logger` | Torreya `@torreya/logger` |
 | `src/scrapers/HtmlScraper.ts` | `HtmlScraper` | PathRipper `fetchPage`, cheerio replaces JSDOM |
-| `src/scrapers/MediaWikiScraper.ts` | `MediaWikiScraper` | New — native `fetch()` to MediaWiki JSON API |
-| `src/scrapers/WikitextParser.ts` | `WikitextParser` | New — `wtf_wikipedia` |
+| `src/scrapers/MediaWikiScraper.ts` | `MediaWikiScraper` | New: native `fetch()` to MediaWiki JSON API |
+| `src/scrapers/WikitextParser.ts` | `WikitextParser` | New: `wtf_wikipedia` |
 | `src/crawlers/LinkLister.ts` | `LinkLister` | PathRipper `linkLister/index.js` |
-| `src/orchestrators/ScrapeOrchestrator.ts` | `ScrapeOrchestrator` | New — pipeline orchestration, three-mode wiki scrape |
-| `src/registry/TaskRegistry.ts` | `TaskRegistry` | New — plugin registration and dynamic loading |
-| `src/registry/PipelineState.ts` | `PipelineState` | New — typed state bridge between scrapers and plugins |
-| `src/config/RipperConfig.ts` | `RipperConfig` | New — replaces hardcoded `config.js` |
-| `src/cli/cli.ts` | `ripperoni` CLI | New — `commander` |
+| `src/orchestrators/ScrapeOrchestrator.ts` | `ScrapeOrchestrator` | New: pipeline orchestration, three-mode wiki scrape |
+| `src/registry/TaskRegistry.ts` | `TaskRegistry` | New: plugin registration and dynamic loading |
+| `src/registry/PipelineState.ts` | `PipelineState` | New: typed state bridge between scrapers and plugins |
+| `src/config/RipperConfig.ts` | `RipperConfig` | New: replaces hardcoded `config.js` |
+| `src/cli/cli.ts` | `ripperoni` CLI | New: `commander` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ npm run build
 ## Create a config
 
 Copy `ripperoni.config.example.json` to `ripperoni.config.json` and edit.
-The unprefixed file is gitignored — it holds your real targets.
+The unprefixed file is gitignored; it holds your real targets.
 
 ```json
 {
@@ -87,5 +87,5 @@ TaskRegistry.register('my-target:parse', async (next, state) => {
 
 ## Where to look next
 
-- [Architecture](./architecture) — pipeline, HTTP machinery, scrapers, source map
-- [Roadmap](./roadmap) — what shipped, what's planned
+- [Architecture](./architecture): pipeline, HTTP machinery, scrapers, source map
+- [Roadmap](./roadmap): what shipped, what's planned

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ title: Ripperoni
 <div style="text-align:center;padding:2rem 0 1rem">
   <img src="/ripperoni.png" alt="Ripperoni" style="max-width:120px;margin:0 auto 1rem" />
   <h1 style="font-size:2.5rem;font-weight:700;margin:0.5rem 0">Ripperoni</h1>
-  <p style="font-size:1.2rem;color:var(--vp-c-text-2);max-width:600px;margin:0 auto 1.5rem">Web ingestion engine — slices wikis, sites, and URL lists into JSON records, one page at a time. Point it at a wiki, a site, or a list of URLs and it hands you the meat.</p>
+  <p style="font-size:1.2rem;color:var(--vp-c-text-2);max-width:600px;margin:0 auto 1.5rem">Web ingestion engine: slices wikis, sites, and URL lists into JSON records, one page at a time. Point it at a wiki, a site, or a list of URLs and it hands you the meat.</p>
   <div style="display:flex;gap:0.75rem;justify-content:center;flex-wrap:wrap;margin-bottom:2rem">
     <a href="/Ripperoni/getting-started" class="VPButton medium brand" style="text-decoration:none;padding:0.5rem 1.25rem;border-radius:4px;background:var(--vp-button-brand-bg);color:var(--vp-button-brand-text);font-weight:500">Get started</a>
     <a href="/Ripperoni/walk-through" class="VPButton medium brand" style="text-decoration:none;padding:0.5rem 1.25rem;border-radius:4px;background:var(--vp-button-brand-bg);color:var(--vp-button-brand-text);font-weight:500">Walk-through</a>
@@ -19,7 +19,7 @@ Point it at a domain. Hand it a plugin. It fetches pages, runs your plugin again
 
 - **Typed pipeline.** Middleware task queue with `async (next, state) => void` signature. Add, compose, and reorder tasks without touching anything else.
 - **HTML scraper.** Native fetch + cheerio. No JSDOM, no headless browser. Returns a `CheerioAPI` handle so you work with familiar selectors.
-- **MediaWiki scraper.** Native fetch against the MediaWiki JSON API. Three modes — single category, categories array, or full-wiki enumeration. Batch wikitext fetch, redirect resolution, `wtf_wikipedia` infobox extraction.
+- **MediaWiki scraper.** Native fetch against the MediaWiki JSON API. Three modes: single category, categories array, or full-wiki enumeration. Batch wikitext fetch, redirect resolution, `wtf_wikipedia` infobox extraction.
 - **Link crawler.** Recursively crawls pages matching domain/target/delimiter regexes. Deduplicates, sorts naturally, respects rate limit.
 - **Retry + backoff.** Exponential backoff with decorrelated jitter. Respects `Retry-After` headers. Classifies errors as `NETWORK / THROTTLED / TIMEOUT / TRANSIENT / PERMANENT`.
 
@@ -32,6 +32,6 @@ cd Ripperoni && npm install && npm run build
 
 ## Where to look next
 
-- [Walk-through](./walk-through) — end-to-end example with a real URL, config, plugin, and output record
-- [Getting started](./getting-started) — install and first run
-- [Architecture](./architecture) — pipeline phases, package boundaries, extension points
+- [Walk-through](./walk-through): end-to-end example with a real URL, config, plugin, and output record
+- [Getting started](./getting-started): install and first run
+- [Architecture](./architecture): pipeline phases, package boundaries, extension points

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,7 +17,7 @@ v2.0.0 is a ground-up rewrite of the 2019 PathRipper. The core pipeline, HTML sc
 | Concurrent pipeline | live | `ConcurrentPipeline.create(pipeline, concurrency)` fans N pages through the same pipeline simultaneously with a semaphore cap. |
 | Task registry | live | `TaskRegistry.register(name, fn)` + dynamic plugin loading via `pipeline: ["my-target:parse"]` in config. Plugins are `.js` files loaded at runtime. |
 | Checkpoint + resume | live | Already-written slugs are detected at run start and skipped. Failed pages are written to `failures.json`; pass `--resume-failures` to retry only those. |
-| Config schema validation | live | AJV validates the config at load time. `RipperConfig.load(path)` throws with the exact field path on any violation — malformed configs fail fast and loudly. |
+| Config schema validation | live | AJV validates the config at load time. `RipperConfig.load(path)` throws with the exact field path on any violation; malformed configs fail fast and loudly. |
 
 ## Planned
 

--- a/docs/usage/cache.md
+++ b/docs/usage/cache.md
@@ -32,12 +32,12 @@ The key is derived from the request: HTTP method + URL, hashed to a fixed-length
 
 | Mode | Reads | Writes | When to use |
 |------|-------|--------|-------------|
-| `read-write` | yes | yes | Normal development — skip the network on subsequent runs. |
+| `read-write` | yes | yes | Normal development; skip the network on subsequent runs. |
 | `read-only` | yes | no | Replay from cache only. Fails if a URL is not cached. Useful for offline reproduction. |
 | `write-only` | no | yes | Always fetch; always cache. Refreshes stale entries. |
 | `off` | no | no | No caching. Every run hits the network. |
 
-Cache hit and rate limiting: On a cache hit, the cached body is returned directly without entering the rate limiter. This is intentional: rate limiting protects the remote server, not your disk. Reading from disk is free and fast. However, cache hits still enter the pipeline — your parse task runs, extraction happens, and files are written.
+Cache hit and rate limiting: On a cache hit, the cached body is returned directly without entering the rate limiter. This is intentional: rate limiting protects the remote server, not your disk. Reading from disk is free and fast. However, cache hits still enter the pipeline; your parse task runs, extraction happens, and files are written.
 
 Concurrent write semantics: If two tasks attempt to cache the same URL simultaneously, the last write wins (second task's body overwrites the first). There's no lock or transaction around cache writes. For a single orchestrator run this isn't an issue because each URL is processed once per concurrency slot. If you run multiple Ripperoni instances against the same cache directory, they'll interfere with each other; use separate cache directories per instance or disable the cache for concurrent runners.
 
@@ -51,7 +51,7 @@ Concurrent write semantics: If two tasks attempt to cache the same URL simultane
 }
 ```
 
-`ttlMs` is in milliseconds. An entry older than `ttlMs` is treated as a miss on read — the fetcher goes to the network and overwrites the entry. Omit `ttlMs` for no expiration.
+`ttlMs` is in milliseconds. An entry older than `ttlMs` is treated as a miss on read; the fetcher goes to the network and overwrites the entry. Omit `ttlMs` for no expiration.
 
 `86400000` = 24 hours. `604800000` = 7 days.
 
@@ -59,11 +59,11 @@ Stale-entry behavior: When you read a cached entry, its timestamp is checked aga
 
 ## LRU eviction
 
-When `maxEntries` is set (programmatic use only — not in the JSON config schema), the cache evicts the oldest entries by `fetchedAt` on write. The JSON config only exposes `dir`, `mode`, and `ttlMs`.
+When `maxEntries` is set (programmatic use only; not in the JSON config schema), the cache evicts the oldest entries by `fetchedAt` on write. The JSON config only exposes `dir`, `mode`, and `ttlMs`.
 
 ## Cache key
 
-The key is derived from `{ method, url }` — the same URL always maps to the same key. Ripperoni only GETs, so in practice the key is the URL hash.
+The key is derived from `{ method, url }`; the same URL always maps to the same key. Ripperoni only GETs, so in practice the key is the URL hash.
 
 ```ts
 const key = ScraperCache.keyFor({ method: 'GET', url });
@@ -71,19 +71,19 @@ const key = ScraperCache.keyFor({ method: 'GET', url });
 
 ## Workflow
 
-First run — cache cold:
+First run; cache cold:
 
 ```
 html:fetch → cache miss → HTTP GET → store in cache → hand HTML to parse task
 ```
 
-Subsequent runs — cache warm:
+Subsequent runs; cache warm:
 
 ```
 html:fetch → cache hit → return cached HTML → hand HTML to parse task
 ```
 
-Network is never touched on a cache hit. This makes iterating on your parse plugin fast — change the plugin, rerun, no waiting.
+Network is never touched on a cache hit. This makes iterating on your parse plugin fast; change the plugin, rerun, no waiting.
 
 ## Cache directory structure
 
@@ -101,7 +101,7 @@ The shard prefix keeps each subdirectory small enough that `readdir()` stays fas
 
 ## Read-only mode failure modes
 
-When `mode: "read-only"` is set, the cache will not write new entries. If a fetch request for a URL that isn't in the cache occurs, the fetcher throws an error immediately — there's no fallback to the network. This is useful for offline development where you've pre-cached a known set of URLs and want to catch typos in your config (a new URL will surface the error immediately, not silently hit the network).
+When `mode: "read-only"` is set, the cache will not write new entries. If a fetch request for a URL that isn't in the cache occurs, the fetcher throws an error immediately; there's no fallback to the network. This is useful for offline development where you've pre-cached a known set of URLs and want to catch typos in your config (a new URL will surface the error immediately, not silently hit the network).
 
 ## Clearing the cache
 
@@ -115,5 +115,5 @@ Or switch `mode` to `write-only` for one run to refresh all entries. In `write-o
 
 ## Related
 
-- [Scrapers](./scrapers) — how HtmlScraper uses the cache
-- [Configuration](./configuration) — cache config schema
+- [Scrapers](./scrapers); how HtmlScraper uses the cache
+- [Configuration](./configuration); cache config schema

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -47,19 +47,19 @@ Each key is a target name (e.g. `"aonprd"`). Value is a target config.
 
 | Key | Type | Default | Notes |
 |-----|------|---------|-------|
-| `rateLimitMs` | integer ≥ 0 | — | Minimum milliseconds between requests. |
-| `jitterMs` | integer ≥ 0 | — | Random jitter added on top of `rateLimitMs`. Applied per request. |
-| `maxRetries` | integer 0–10 | — | Retry attempts on transient errors. |
-| `retryBaseDelayMs` | integer ≥ 100 | — | Base delay for retry backoff. |
-| `retryMaxDelayMs` | integer ≥ 1000 | — | Backoff ceiling. |
+| `rateLimitMs` | integer ≥ 0 |  | Minimum milliseconds between requests. |
+| `jitterMs` | integer ≥ 0 |  | Random jitter added on top of `rateLimitMs`. Applied per request. |
+| `maxRetries` | integer 0–10 |  | Retry attempts on transient errors. |
+| `retryBaseDelayMs` | integer ≥ 100 |  | Base delay for retry backoff. |
+| `retryMaxDelayMs` | integer ≥ 1000 |  | Backoff ceiling. |
 | `concurrency` | integer 1–32 | `1` | Parallel fetch/process slots. |
-| `maxPages` | integer ≥ 0 | — | Stop after processing this many pages. |
-| `headers` | object | — | Additional HTTP headers. Include `User-Agent`. |
-| `outputSchema` | string | — | Path to a JSON Schema file. Records that fail validation are handled per `onSchemaError`. |
-| `onSchemaError` | `"halt"` \| `"skip"` \| `"warn"` | — | What to do when a record fails schema validation. |
-| `mapping` | object | — | Field-rename map applied after plugin output. |
-| `cache` | CacheConfig | — | See [Cache](./cache). |
-| `crawler` | CrawlerConfig | — | Inline crawler config for this target. |
+| `maxPages` | integer ≥ 0 |  | Stop after processing this many pages. |
+| `headers` | object |  | Additional HTTP headers. Include `User-Agent`. |
+| `outputSchema` | string |  | Path to a JSON Schema file. Records that fail validation are handled per `onSchemaError`. |
+| `onSchemaError` | `"halt"` \| `"skip"` \| `"warn"` |  | What to do when a record fails schema validation. |
+| `mapping` | object |  | Field-rename map applied after plugin output. |
+| `cache` | CacheConfig |  | See [Cache](./cache). |
+| `crawler` | CrawlerConfig |  | Inline crawler config for this target. |
 
 Concurrency bound rationale: Concurrency is clamped to 1–32 to prevent runaway parallelism. At concurrency 32, you can have 32 HTTP requests in flight simultaneously. This is usually enough to saturate downstream bandwidth and quickly hit many servers' rate limits. Beyond 32, the marginal benefit drops and the risk of getting blocked increases. If you need more parallelism, run multiple Ripperoni instances.
 
@@ -170,8 +170,8 @@ See [Cache](./cache) for sharding, eviction, and TTL behavior.
 
 ## Related
 
-- [Pipeline](./pipeline) — task registration and state shape
-- [Scrapers](./scrapers) — HtmlScraper vs MediaWikiScraper
-- [MediaWiki](./mediawiki) — three enumeration modes
-- [Crawler](./crawler) — LinkLister behavior
-- [Cache](./cache) — read/write modes, TTL, eviction
+- [Pipeline](./pipeline); task registration and state shape
+- [Scrapers](./scrapers); HtmlScraper vs MediaWikiScraper
+- [MediaWiki](./mediawiki); three enumeration modes
+- [Crawler](./crawler); LinkLister behavior
+- [Cache](./cache); read/write modes, TTL, eviction

--- a/docs/usage/crawler.md
+++ b/docs/usage/crawler.md
@@ -5,7 +5,7 @@ title: Crawler
 
 # Crawler
 
-`LinkLister` recursively follows links from one or more starting URLs and returns the set of URLs that match your target pattern. It doesn't scrape content — it builds a URL list. You hand that list to a scraper.
+`LinkLister` recursively follows links from one or more starting URLs and returns the set of URLs that match your target pattern. It doesn't scrape content; it builds a URL list. You hand that list to a scraper.
 
 ## Three regexes
 
@@ -39,8 +39,8 @@ Three-regex decision tree: For each link the crawler finds, it applies three fil
 
 In the example above:
 - Any link to a different domain is ignored.
-- Links to `Feats.aspx` (without query string) are traversed — they're list pages.
-- Links to `Feats.aspx?ID=\d+` are collected — they're detail pages.
+- Links to `Feats.aspx` (without query string) are traversed: they're list pages.
+- Links to `Feats.aspx?ID=\d+` are collected; they're detail pages.
 - The starting URL itself is traversed first.
 
 Note: Every link must match `domain` to be considered. If a link doesn't match `domain`, it's not evaluated against `delimiter` or `target` at all. This keeps crawls confined to their target site.
@@ -48,8 +48,8 @@ Note: Every link must match `domain` to be considered. If a link doesn't match `
 ## Visited and collected sets
 
 Two internal sets track state:
-- `#visited` — URLs already traversed (prevents loops).
-- `#collected` — URLs matched as results.
+- `#visited`: URLs already traversed (prevents loops).
+- `#collected`: URLs matched as results.
 
 A URL can be traversed without being collected. The crawler follows list pages but only hands back detail pages.
 
@@ -61,7 +61,7 @@ Traversal is breadth-first, not depth-first. All URLs at a given frontier depth 
 
 ## Revisit semantics
 
-The crawler tracks `#visited` (URLs already traversed) and `#collected` (URLs in results). Once a URL is added to `visited`, revisiting it from another depth is skipped — no duplicate fetches. This prevents infinite loops if your site has bidirectional links. A URL can be traversed without being collected (list pages are traversed but not returned). A URL is collected only if it matches all three regexes.
+The crawler tracks `#visited` (URLs already traversed) and `#collected` (URLs in results). Once a URL is added to `visited`, revisiting it from another depth is skipped; no duplicate fetches. This prevents infinite loops if your site has bidirectional links. A URL can be traversed without being collected (list pages are traversed but not returned). A URL is collected only if it matches all three regexes.
 
 ## maxPages
 
@@ -73,9 +73,9 @@ Hard ceiling on collected results. The crawl stops as soon as this many URLs hav
 
 ## Deduplication and sorting
 
-Results are deduplicated automatically — the same URL appearing at multiple traversal depths is collected once. The dedupe happens at collection time: if URL A matches `target` at depth 0 and again at depth 2, it's added to results on the first match; the second match sees it's already in `collected` and skips it.
+Results are deduplicated automatically; the same URL appearing at multiple traversal depths is collected once. The dedupe happens at collection time: if URL A matches `target` at depth 0 and again at depth 2, it's added to results on the first match; the second match sees it's already in `collected` and skips it.
 
-Numeric collation rationale: By default, `Item-10` sorts before `Item-2` because string comparison is lexicographic (`"1" < "2"`). Numeric-aware collation sorts by the numeric value of each segment, so `Item-2` then `Item-10`. This makes URL lists sortable and diff-able across runs — you can `diff before.json after.json` and see only actual changes, not reordering artifacts.
+Numeric collation rationale: By default, `Item-10` sorts before `Item-2` because string comparison is lexicographic (`"1" < "2"`). Numeric-aware collation sorts by the numeric value of each segment, so `Item-2` then `Item-10`. This makes URL lists sortable and diff-able across runs; you can `diff before.json after.json` and see only actual changes, not reordering artifacts.
 
 Sorting uses a numeric-aware collator: `Item-10` sorts after `Item-9`, not between `Item-1` and `Item-2`. Consistent ordering makes the output list diff-able.
 
@@ -83,7 +83,7 @@ Sorting uses a numeric-aware collator: `Item-10` sorts after `Item-9`, not betwe
 
 Two ways to configure a crawler:
 
-**Top-level** (`crawlers` block) — runs as a standalone job, produces a URL list:
+**Top-level** (`crawlers` block); runs as a standalone job, produces a URL list:
 
 ```json
 {
@@ -99,7 +99,7 @@ Two ways to configure a crawler:
 }
 ```
 
-**Inline** (`targets[].crawler`) — the scrape target crawls before it fetches:
+**Inline** (`targets[].crawler`); the scrape target crawls before it fetches:
 
 ```json
 {
@@ -123,6 +123,6 @@ In the inline case, the orchestrator runs the crawler first, then scrapes each c
 
 ## Related
 
-- [Configuration](./configuration) — crawler config schema
-- [Scrapers](./scrapers) — what happens after the crawler hands back URLs
-- [Cache](./cache) — crawler requests go through the rate limiter but not the cache
+- [Configuration](./configuration); crawler config schema
+- [Scrapers](./scrapers); what happens after the crawler hands back URLs
+- [Cache](./cache); crawler requests go through the rate limiter but not the cache

--- a/docs/usage/mediawiki.md
+++ b/docs/usage/mediawiki.md
@@ -13,9 +13,9 @@ Problem being solved: Different wikis have different structures. Some have a fla
 
 Decision tree: The `ScrapeOrchestrator` picks the mode based on what's present in your config or CLI:
 
-1. **`--category` CLI flag** — scrape one named category (overrides config).
-2. **`categories[]` in config** — iterate each category, deduplicate page titles across all categories, scrape the union.
-3. **Neither** — enumerate every article in main namespace via `fetchAllPages()`.
+1. **`--category` CLI flag**: scrape one named category (overrides config).
+2. **`categories[]` in config**: iterate each category, deduplicate page titles across all categories, scrape the union.
+3. **Neither**: enumerate every article in main namespace via `fetchAllPages()`.
 
 This ordering means: a CLI flag overrides config (don't allow config to force a full-wiki scrape if you wanted a single category). If config has `categories`, use them (don't hit the full wiki). Otherwise, fall back to full wiki.
 
@@ -52,7 +52,7 @@ Pages are fetched in batches of up to `batchSize` (default 50, MediaWiki's maxim
 
 Batch partial-failure behavior: If a batch request includes 50 page titles and one of them is a redirect or missing, the API returns the other 49 pages successfully. There's no explicit "failed pages" list; pages that exist are returned, missing pages are silently omitted. Your parse task receives only the pages that the API returned. If you're expecting 50 pages and get 49, something was missing or a redirect resolved to a different page title.
 
-Redirect resolution: The API resolves redirects transparently. If page A is a redirect to page B, the API returns page B's content under the original page A title in the request. The scraper doesn't know a redirect happened; it just gets the content. This is why `maxPages` stops after this many distinct titles are scraped, not after this many API requests — 50 pages in one batch might resolve to 49 unique pages if one was a redirect.
+Redirect resolution: The API resolves redirects transparently. If page A is a redirect to page B, the API returns page B's content under the original page A title in the request. The scraper doesn't know a redirect happened; it just gets the content. This is why `maxPages` stops after this many distinct titles are scraped, not after this many API requests; 50 pages in one batch might resolve to 49 unique pages if one was a redirect.
 
 Rate limiting per batch: Even though one API call fetches 50 pages, the rate limiter counts it as one request. If `rateLimitMs: 500`, you issue batch requests 500ms apart. Filling 1000 pages in batches of 50 means 20 batch requests, each separated by 500ms, for a total of ~10 seconds (ignoring any retry delays).
 
@@ -72,10 +72,10 @@ interface ParsedPageInterface {
 Two typed accessor methods so you don't write null-checks at every call site:
 
 ```ts
-// infoboxField(key) — returns string | null
+// infoboxField(key); returns string | null
 const name = parser.infoboxField('name');
 
-// infoboxNumber(key) — parses and returns number | null
+// infoboxNumber(key); parses and returns number | null
 const level = parser.infoboxNumber('level');
 ```
 
@@ -90,7 +90,7 @@ const level = parseInt(page.infobox['level'] ?? '', 10) || null;
 const displayName = page.infobox['name'] ?? page.title;
 ```
 
-These live on `WikitextParser`. In a plugin, use `state.input.parsedPage` directly — it's already been parsed before your task runs.
+These live on `WikitextParser`. In a plugin, use `state.input.parsedPage` directly; it's already been parsed before your task runs.
 
 ## Plugin pattern for MediaWiki
 
@@ -132,19 +132,19 @@ Cap the number of pages processed:
 "maxPages": 100
 ```
 
-Applied after enumeration — the scraper stops processing after this many pages regardless of how many the category or `allpages` enumeration returns. Useful for smoke tests against a full wiki without waiting for all 10,000 articles.
+Applied after enumeration; the scraper stops processing after this many pages regardless of how many the category or `allpages` enumeration returns. Useful for smoke tests against a full wiki without waiting for all 10,000 articles.
 
 ## Rate limiting and pagination
 
-`rateLimitMs` and `jitterMs` apply per API request (each batch counts as one request). For a large wiki, expect a long run at conservative rates. The cache is your friend — the first run is slow, subsequent runs skip the network entirely for cached pages.
+`rateLimitMs` and `jitterMs` apply per API request (each batch counts as one request). For a large wiki, expect a long run at conservative rates. The cache is your friend; the first run is slow, subsequent runs skip the network entirely for cached pages.
 
-Pagination stop condition: The `fetchAllPages()` method pages through the entire namespace using the MediaWiki `allpages` API. It stops when the API returns an empty batch (no more pages in the namespace). The batch is counted toward `maxPages` — if you set `maxPages: 100` and the API returns pages in batches of 50, you get one full batch (50 pages) and then the second batch stops because you've hit the limit. The orchestrator stops calling `fetchAllPages()` once enough pages have been fetched.
+Pagination stop condition: The `fetchAllPages()` method pages through the entire namespace using the MediaWiki `allpages` API. It stops when the API returns an empty batch (no more pages in the namespace). The batch is counted toward `maxPages`; if you set `maxPages: 100` and the API returns pages in batches of 50, you get one full batch (50 pages) and then the second batch stops because you've hit the limit. The orchestrator stops calling `fetchAllPages()` once enough pages have been fetched.
 
 `batchSize` worked example: If you set `batchSize: 50` and enumerate 1000 pages, that's 20 API requests, each with 50 page titles in the `titles` parameter. If you set `batchSize: 10`, that's 100 requests. Larger batches use less bandwidth and API calls but are riskier if a batch request times out (you lose more pages). The MediaWiki API caps individual requests at 50; Ripperoni respects that by clamping your config value.
 
 ## Related
 
-- [Scrapers](./scrapers) — HtmlScraper vs MediaWikiScraper comparison
-- [Configuration](./configuration) — full mediawiki config schema
-- [Cache](./cache) — caching wiki responses
-- [Plugins](./plugins) — full plugin authoring guide
+- [Scrapers](./scrapers); HtmlScraper vs MediaWikiScraper comparison
+- [Configuration](./configuration); full mediawiki config schema
+- [Cache](./cache); caching wiki responses
+- [Plugins](./plugins); full plugin authoring guide

--- a/docs/usage/pipeline.md
+++ b/docs/usage/pipeline.md
@@ -7,15 +7,15 @@ title: Pipeline
 
 The pipeline is a typed async middleware queue. Tasks receive `(next, state)`. Call `next()` to hand off; skip it to terminate the chain early.
 
-Problem: Ripperoni needs to fetch a page, parse it with domain-specific logic (your plugin), and write it to disk — three separate concerns. The pipeline lets you plug in custom extraction logic (your parse task) without touching the HTTP or I/O machinery. Each task sees the state that previous tasks wrote and can add to it or skip execution.
+Problem: Ripperoni needs to fetch a page, parse it with domain-specific logic (your plugin), and write it to disk; three separate concerns. The pipeline lets you plug in custom extraction logic (your parse task) without touching the HTTP or I/O machinery. Each task sees the state that previous tasks wrote and can add to it or skip execution.
 
-State machine: Each task either calls `await next()` to advance the queue or returns without calling it to terminate. There's no error handling middleware — if your parse task encounters invalid HTML, it just doesn't set `state.output` and skips `next()`. The write task sees `output === null` and decides (per config) whether to fail, warn, or skip the file. This gives you local control without exception bubbling.
+State machine: Each task either calls `await next()` to advance the queue or returns without calling it to terminate. There's no error handling middleware; if your parse task encounters invalid HTML, it just doesn't set `state.output` and skips `next()`. The write task sees `output === null` and decides (per config) whether to fail, warn, or skip the file. This gives you local control without exception bubbling.
 
 ```ts
 type TaskFnType<TState> = (next: () => Promise<void>, state: TState) => Promise<void>
 ```
 
-`TState` extends `Record<string, unknown>`. Tasks mutate state directly — the same reference flows through the whole chain.
+`TState` extends `Record<string, unknown>`. Tasks mutate state directly; the same reference flows through the whole chain.
 
 ```mermaid
 flowchart TD
@@ -70,11 +70,11 @@ interface PipelineStateInterface {
 }
 ```
 
-`state.input.html` — raw HTML string, set by `html:fetch`.
-`state.input.wikitext` — raw wikitext string, set by wiki fetch.
-`state.input.url` — the URL fetched.
+`state.input.html`; raw HTML string, set by `html:fetch`.
+`state.input.wikitext`; raw wikitext string, set by wiki fetch.
+`state.input.url`; the URL fetched.
 
-`state.output` — set by your parse task. `json:write` serializes this to disk.
+`state.output`; set by your parse task. `json:write` serializes this to disk.
 
 Tasks can attach extra keys using the `Record<string, unknown>` index signature. This is how tasks pass data to each other without coupling to canonical fields.
 
@@ -120,17 +120,17 @@ html:fetch  →  mysite:parse  →  json:write
 
 `html:fetch` must come first. `json:write` must come last. Your parse task goes in between.
 
-Early termination: If `html:fetch` encounters a permanent HTTP error (e.g. 404) it throws, halting the pipeline. If your parse task finds malformed HTML it can skip `await next()` to prevent `json:write` from running. There's no explicit error handling middleware — control flow is implicit: a task either advances the queue or halts it.
+Early termination: If `html:fetch` encounters a permanent HTTP error (e.g. 404) it throws, halting the pipeline. If your parse task finds malformed HTML it can skip `await next()` to prevent `json:write` from running. There's no explicit error handling middleware; control flow is implicit: a task either advances the queue or halts it.
 
 Unregistered task error: If your config names a pipeline task that doesn't exist (e.g. `["html:fetch", "nonexistent:parse", "json:write"]`), the error surfaces at orchestration time (when building the pipeline), not at runtime. The orchestrator calls `TaskRegistry.get()` which throws if the task is not registered. This means typos in your config fail fast before the scrape starts.
 
-For wiki targets, the orchestrator handles the fetch — your task receives a pre-populated `state.input` and sets `state.output`. The write task is always added last by the orchestrator.
+For wiki targets, the orchestrator handles the fetch; your task receives a pre-populated `state.input` and sets `state.output`. The write task is always added last by the orchestrator.
 
-Task-name collision: If two tasks register the same name (e.g. two plugins both call `TaskRegistry.register('aonprd:parse', ...)`), the second registration overwrites the first. There's no warning or error. The last-loaded plugin wins. This is by design — your test plugins can shadow the production ones. If you're seeing the wrong task execute, check plugin load order in your config.
+Task-name collision: If two tasks register the same name (e.g. two plugins both call `TaskRegistry.register('aonprd:parse', ...)`), the second registration overwrites the first. There's no warning or error. The last-loaded plugin wins. This is by design; your test plugins can shadow the production ones. If you're seeing the wrong task execute, check plugin load order in your config.
 
 ## ScrapeOrchestrator
 
-You don't build the pipeline directly — the `ScrapeOrchestrator` builds it per page from the target config. It:
+You don't build the pipeline directly; the `ScrapeOrchestrator` builds it per page from the target config. It:
 
 1. Resolves the target's `pipeline` array against the registry.
 2. Optionally prepends the fetch task.
@@ -170,7 +170,7 @@ state.output = {
 
 ## Related
 
-- [Configuration](./configuration) — pipeline declaration in config
-- [Scrapers](./scrapers) — what html:fetch hands your plugin
-- [MediaWiki](./mediawiki) — wiki-specific state shape
-- [Plugins](./plugins) — full plugin authoring guide
+- [Configuration](./configuration); pipeline declaration in config
+- [Scrapers](./scrapers); what html:fetch hands your plugin
+- [MediaWiki](./mediawiki); wiki-specific state shape
+- [Plugins](./plugins); full plugin authoring guide

--- a/docs/usage/plugins.md
+++ b/docs/usage/plugins.md
@@ -15,7 +15,7 @@ type TaskFnType<TState> = (next: () => Promise<void>, state: TState) => Promise<
 
 The task receives `next` (call it when you're done) and `state` (the pipeline state for the current page). Call `await next()` at the end.
 
-Error handling: If your plugin throws an error, the error bubbles out of the pipeline and halts the orchestrator. There's no error recovery — the run fails. If you want to skip a malformed page gracefully, don't throw; instead, skip `await next()` or set a flag on state. The write task downstream can check the flag and decide whether to write.
+Error handling: If your plugin throws an error, the error bubbles out of the pipeline and halts the orchestrator. There's no error recovery; the run fails. If you want to skip a malformed page gracefully, don't throw; instead, skip `await next()` or set a flag on state. The write task downstream can check the flag and decide whether to write.
 
 Plugin-load timing: Plugins are loaded by `TaskRegistry.load()` which imports the plugin file as an ES module. The module's top-level `TaskRegistry.register()` calls fire immediately. This happens before the orchestrator starts scraping, during the config parsing phase. If you have a syntax error in your plugin, you'll see it before any pages are scraped.
 
@@ -79,7 +79,7 @@ TaskRegistry.register('mysite:parse', async (next, state) => {
 });
 ```
 
-No HTTP in the plugin. No file I/O. No cheerio initialization — `html:fetch` has already fetched; you load the string into cheerio yourself. The pipeline handles the I/O, you handle the extraction.
+No HTTP in the plugin. No file I/O. No cheerio initialization; `html:fetch` has already fetched; you load the string into cheerio yourself. The pipeline handles the I/O, you handle the extraction.
 
 ## MediaWiki plugin
 
@@ -125,7 +125,7 @@ Every record should have `_type`. It's the field downstream tools (like Squashag
 
 ## The _source block
 
-Every record should have `_source`. Include at minimum `target`, `url`, and `plugin`. Squashage reads `_source.url` to derive graph IRIs — if it's missing, IRI derivation falls back to a default.
+Every record should have `_source`. Include at minimum `target`, `url`, and `plugin`. Squashage reads `_source.url` to derive graph IRIs; if it's missing, IRI derivation falls back to a default.
 
 ```ts
 _source: {
@@ -185,7 +185,7 @@ No HTTP, no file system, no network. Just the extraction logic.
 
 ## Related
 
-- [Pipeline](./pipeline) — how the task queue works
-- [Scrapers](./scrapers) — what state.input looks like per scraper type
-- [MediaWiki](./mediawiki) — infobox helpers and wiki-specific state
-- [Configuration](./configuration) — how to declare plugins in config
+- [Pipeline](./pipeline); how the task queue works
+- [Scrapers](./scrapers); what state.input looks like per scraper type
+- [MediaWiki](./mediawiki); infobox helpers and wiki-specific state
+- [Configuration](./configuration); how to declare plugins in config

--- a/docs/usage/scrapers.md
+++ b/docs/usage/scrapers.md
@@ -5,17 +5,17 @@ title: Scrapers
 
 # Scrapers
 
-Two scraper classes. One for HTML, one for MediaWiki. Neither knows about the pipeline. You don't use them directly — the orchestrator does — but knowing what they hand back tells you what your plugin receives.
+Two scraper classes. One for HTML, one for MediaWiki. Neither knows about the pipeline. You don't use them directly; the orchestrator does; but knowing what they hand back tells you what your plugin receives.
 
 ## HtmlScraper
 
 Native `fetch` + cheerio. No JSDOM. No headless browser. No JavaScript execution.
 
-Fetch state machine: When you call `HtmlScraper.fetch(url)`, this sequence runs: (1) rate limiter delays if needed, (2) cache is checked — if hit, return immediately (skip steps 3–5); (3) HTTP GET is issued with configured headers and timeout; (4) on error, ErrorClassifier decides if it's retryable — if yes, RetryExecutor waits and retries; if no, error is thrown; (5) on success (200), the response body is stored in cache and returned to the pipeline.
+Fetch state machine: When you call `HtmlScraper.fetch(url)`, this sequence runs: (1) rate limiter delays if needed, (2) cache is checked; if hit, return immediately (skip steps 3–5); (3) HTTP GET is issued with configured headers and timeout; (4) on error, ErrorClassifier decides if it's retryable; if yes, RetryExecutor waits and retries; if no, error is thrown; (5) on success (200), the response body is stored in cache and returned to the pipeline.
 
 What it does:
 1. Applies rate limiting and jitter from the target config.
-2. Checks the cache — returns the cached body on a hit.
+2. Checks the cache; returns the cached body on a hit.
 3. On a miss: sends the HTTP request. On error: retries with exponential backoff.
 4. On success: stores the body in cache, returns the page.
 
@@ -114,7 +114,7 @@ Use `MediaWikiScraper` (`mediawiki` block in config) when:
 
 ## Related
 
-- [Configuration](./configuration) — how to declare targets and mediawiki blocks
-- [MediaWiki](./mediawiki) — enumeration modes, infobox helpers
-- [Cache](./cache) — how caching integrates with both scrapers
-- [Pipeline](./pipeline) — what state.input looks like inside a parse task
+- [Configuration](./configuration); how to declare targets and mediawiki blocks
+- [MediaWiki](./mediawiki); enumeration modes, infobox helpers
+- [Cache](./cache); how caching integrates with both scrapers
+- [Pipeline](./pipeline); what state.input looks like inside a parse task

--- a/docs/walk-through.md
+++ b/docs/walk-through.md
@@ -1,10 +1,10 @@
 # Walk-through
 
-One concrete end-to-end example from URL to structured JSON record. The target is the [Archives of Nethys](https://2e.aonprd.com/) (aonprd) — the Pathfinder Second Edition rules reference. All of this is in `tests/e2e/fixtures/` and `plugins/aonprd/`.
+One concrete end-to-end example from URL to structured JSON record. The target is the [Archives of Nethys](https://2e.aonprd.com/) (aonprd): the Pathfinder Second Edition rules reference. All of this is in `tests/e2e/fixtures/` and `plugins/aonprd/`.
 
 ---
 
-## Before — the input
+## Before: the input
 
 Point Ripperoni at a detail page:
 
@@ -12,7 +12,7 @@ Point Ripperoni at a detail page:
 https://2e.aonprd.com/Feats.aspx?ID=750
 ```
 
-That URL resolves to the Power Attack feat page — a standard AON HTML page with a structured `<h1>`, a header field table, a body block, and inline links to other rules entries.
+That URL resolves to the Power Attack feat page: a standard AON HTML page with a structured `<h1>`, a header field table, a body block, and inline links to other rules entries.
 
 Ripperoni fetches the raw HTML, hands it to the configured plugin, and the plugin extracts a typed record. You never see raw HTML in your output.
 
@@ -54,7 +54,7 @@ Pipeline step breakdown:
 | Step | What it does |
 |------|-------------|
 | `html:fetch` | Rate-limited fetch with retry + backoff. Respects `Retry-After`. Reads from cache on hits. |
-| `aonprd:parse` | Plugin — loads the HTML into cheerio, extracts structured fields, writes `state.output`. |
+| `aonprd:parse` | Plugin: loads the HTML into cheerio, extracts structured fields, writes `state.output`. |
 | `json:write` | Writes `state.output` to `./output/aonprd/<slug>.json`. |
 
 ---
@@ -101,11 +101,11 @@ export function extractFeat($: CheerioAPI, url: string): FeatOutput {
 }
 ```
 
-This is the only domain-specific code. `getField`, `htmlToText`, and `harvestLinks` are shared helpers in `plugins/aonprd/common.ts`. `extractFeat` receives a `CheerioAPI` instance — no HTTP, no I/O, no side effects.
+This is the only domain-specific code. `getField`, `htmlToText`, and `harvestLinks` are shared helpers in `plugins/aonprd/common.ts`. `extractFeat` receives a `CheerioAPI` instance; no HTTP, no I/O, no side effects.
 
 ---
 
-## After — the JSON record
+## After: the JSON record
 
 ```json
 {
@@ -131,16 +131,16 @@ The `_source` block makes the record traceable back to its origin page. Downstre
 
 ## What ran in between
 
-1. **Rate-limited fetch** — waited `rateLimitMs` (1000ms) + up to `jitterMs` (250ms) random jitter before the request.
-2. **Cache check** — first run: cache miss, HTTP GET. Subsequent runs: cache hit, no network request.
-3. **Retry logic** — on transient failures (5xx, network timeout), retried up to `maxRetries` times with exponential backoff capped at `retryMaxDelayMs`.
-4. **Plugin executed** — `aonprd:parse` called with `(next, state)`. `state.input.html` contained the raw page HTML; the extractor ran cheerio selectors against it.
-5. **Record written** — `json:write` serialized `state.output` to `./output/aonprd/feats-750.json`.
+1. **Rate-limited fetch**: waited `rateLimitMs` (1000ms) + up to `jitterMs` (250ms) random jitter before the request.
+2. **Cache check**: first run: cache miss, HTTP GET. Subsequent runs: cache hit, no network request.
+3. **Retry logic**: on transient failures (5xx, network timeout), retried up to `maxRetries` times with exponential backoff capped at `retryMaxDelayMs`.
+4. **Plugin executed**: `aonprd:parse` called with `(next, state)`. `state.input.html` contained the raw page HTML; the extractor ran cheerio selectors against it.
+5. **Record written**: `json:write` serialized `state.output` to `./output/aonprd/feats-750.json`.
 
 ---
 
 ## Where to look next
 
-- [Architecture](./architecture) — pipeline phases, scraper contracts, extension points
-- [Getting started](./getting-started) — install, config, and first run
-- [Roadmap](./roadmap) — planned and shipped features
+- [Architecture](./architecture); pipeline phases, scraper contracts, extension points
+- [Getting started](./getting-started); install, config, and first run
+- [Roadmap](./roadmap); planned and shipped features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ripperoni",
   "version": "2.3.0",
-  "description": "Web ingestion engine — slices wikis, sites, and URL lists into JSON records, one page at a time. Pairs with Squashage for RDF graph reconstitution.",
+  "description": "Web ingestion engine; slices wikis, sites, and URL lists into JSON records, one page at a time. Pairs with Squashage for RDF graph reconstitution.",
   "type": "module",
   "bin": {
     "ripperoni": "./dist/cli/cli.js"


### PR DESCRIPTION
## Summary
Replace ~95 em-dashes (`—`) across user-facing docs with plain punctuation per the audit punch list. List/definition items get `: `, clause joins get `; `, mid-sentence asides get `, `. CHANGELOG.md history left untouched.

## Type of Change
- [ ] Feature
- [ ] Breaking change
- [ ] Bug fix
- [x] Documentation
- [ ] Refactoring
- [x] Chore

## Testing
- [x] typecheck passes
- [x] lint passes
- [x] grep verifies zero em-dashes remaining in audited files

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Documentation updated (CHANGELOG.md Unreleased entry)
- [x] All tests pass

## Related Issues
N/A — feedback from audit pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
