### PR TITLE
chore(release): 2.4.0

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Comment on PR (if violations found)
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,7 +25,7 @@ jobs:
       - run: npm ci
       - run: npm run docs:build
       - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with: { path: docs/.vitepress/dist }
 
   deploy:
@@ -35,5 +35,5 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5
         id: deployment

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Upload audit report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: npm-audit-report
           path: npm-audit-report.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Em-dashes (`—`) replaced with plain punctuation (`: ` for list/definition items, `; ` for clause joins, `, ` mid-sentence) across `README.md`, `docs/**/*.md`, `package.json`, and `docs/.vitepress/config.ts`. ~95 occurrences total. CHANGELOG history left untouched.
+
 ### Added
 
 - Mechanism-depth expansions across user-facing docs (architecture, pipeline, cache, scrapers, configuration, crawler, mediawiki, plugins) following the yamete-fidelity bar: problem framing, state machines, error propagation, parameter rationale, edge cases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Mechanism-depth expansions across user-facing docs (architecture, pipeline, cache, scrapers, configuration, crawler, mediawiki, plugins) following the yamete-fidelity bar: problem framing, state machines, error propagation, parameter rationale, edge cases.
+
+### Changed
+
+- GitHub Actions baseline: `actions/upload-artifact` 4 → 7, `actions/upload-pages-artifact` 3 → 5, `actions/deploy-pages` 4 → 5, `actions/github-script` 7 → 9.
+
 ## [2.3.0] - 2026-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-05-06
+
 ### Changed
 
 - Em-dashes (`—`) replaced with plain punctuation (`: ` for list/definition items, `; ` for clause joins, `, ` mid-sentence) across `README.md`, `docs/**/*.md`, `package.json`, and `docs/.vitepress/config.ts`. ~95 occurrences total. CHANGELOG history left untouched.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm run build
 ## Quickstart
 
 ```bash
-# Scrape a MediaWiki target — one category
+# Scrape a MediaWiki target: one category
 ripperoni scrape \
   --target <your-wiki-target> \
   --category "Example Category Name" \
@@ -55,7 +55,7 @@ ripperoni crawl \
   --delimiter "category"
 ```
 
-Copy `ripperoni.config.example.json` to `ripperoni.config.json` and edit. The unprefixed file is gitignored — it holds your real targets.
+Copy `ripperoni.config.example.json` to `ripperoni.config.json` and edit. The unprefixed file is gitignored; it holds your real targets.
 
 ## Scripts
 
@@ -93,7 +93,7 @@ All scraper targets live in `ripperoni.config.json` (the project itself names no
 }
 ```
 
-`categories` is optional — omit it to scrape every article in the wiki via the allpages API. `tasks` points at user-written parse plugins that run through the pipeline before each page is written.
+`categories` is optional; omit it to scrape every article in the wiki via the allpages API. `tasks` points at user-written parse plugins that run through the pipeline before each page is written.
 
 The config is validated on load against the internal JSON Schema; malformed files fail fast with a precise field-path error message.
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -33,7 +33,7 @@ const sidebar = [
 export default defineConfig({
   appearance: themeConfig.appearance,
   base: '/Ripperoni/',
-  description: 'Web ingestion engine — slices wikis, sites, and URL lists into JSON records. Feed them into Squashage for graph reconstitution.',
+  description: 'Web ingestion engine; slices wikis, sites, and URL lists into JSON records. Feed them into Squashage for graph reconstitution.',
   head: [
     ['link', { rel: 'icon', type: 'image/png', href: '/Ripperoni/ripperoni.png' }],
   ],

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Three independent concerns — **pipeline**, **HTTP machinery**, and **scrapers** — compose to produce a scraping job. Nothing in the pipeline knows about HTTP. Nothing in the HTTP layer knows about MediaWiki. The scraper classes are pure data accessors that return typed results.
+Three independent concerns (**pipeline**, **HTTP machinery**, and **scrapers**) compose to produce a scraping job. Nothing in the pipeline knows about HTTP. Nothing in the HTTP layer knows about MediaWiki. The scraper classes are pure data accessors that return typed results.
 
 ## Module graph
 
@@ -85,19 +85,19 @@ await pipeline.execute(PipelineState.fromWikiPage('my-target', page));
 type TaskFnType<TState> = (next: NextFnType, state: TState) => Promise<void>
 ```
 
-`TState` must extend `Record<string, unknown>`. Tasks mutate state directly — the pipeline passes the same reference through the chain.
+`TState` must extend `Record<string, unknown>`. Tasks mutate state directly; the pipeline passes the same reference through the chain.
 
 Why this matters: If a task decides to bail out (malformed HTML, missing required field), it skips `await next()` and the write task never runs. You don't need error handling middleware; you just don't call `next()`. This is simpler than try/catch chains and keeps the control flow local to each task.
 
 ## HTTP machinery
 
-Three composable classes — `RateLimiter`, `RetryExecutor`, and `ErrorClassifier` — form the HTTP stack, each injected independently.
+Three composable classes (`RateLimiter`, `RetryExecutor`, and `ErrorClassifier`) form the HTTP stack, each injected independently.
 
 Problem being solved: HTTP is unreliable. Networks fail. Servers get overloaded and 429. Caches go stale. When Ripperoni fetches a page, it needs to retry transient errors but give up on permanent ones, respect `Retry-After` headers, and throttle to avoid hammering the target server. The three-class stack keeps these concerns separate so you can swap implementations or compose them differently in tests.
 
 Error propagation rules: An error enters `ErrorClassifier` which examines the error object or HTTP status code. If the classifier says it's retryable (`NETWORK`, `TIMEOUT`, `THROTTLED`, `TRANSIENT`), the error goes back to `RetryExecutor` which waits and tries again. If the classifier says it's permanent (`PERMANENT`, `VALIDATION`, `RESOURCE`), the error is thrown immediately. A 404 is permanent (throw immediately). A 500 is transient (retry). A 429 is throttled (retry with `Retry-After` delay).
 
-Cache and retry interaction: The cache sits upstream of this stack. A cache hit bypasses the entire HTTP machinery — the cached body is returned directly to the pipeline. A cache miss enters the HTTP stack: rate limiter makes you wait, then RetryExecutor calls fetch, then ErrorClassifier decides if we retry. On success, the response is cached. So the first fetch of a URL pays the full HTTP + retry cost; the second fetch hits cache and costs almost nothing.
+Cache and retry interaction: The cache sits upstream of this stack. A cache hit bypasses the entire HTTP machinery; the cached body is returned directly to the pipeline. A cache miss enters the HTTP stack: rate limiter makes you wait, then RetryExecutor calls fetch, then ErrorClassifier decides if we retry. On success, the response is cached. So the first fetch of a URL pays the full HTTP + retry cost; the second fetch hits cache and costs almost nothing.
 
 ```mermaid
 graph LR
@@ -148,7 +148,7 @@ Backoff formula: `delay = min(baseDelayMs * 2^attempt, maxDelayMs) ± jitter`. F
 
 Token-bucket backed by `bottleneck`. Factory methods: `RateLimiter.perSecond(n)` for throughput-based limits, `RateLimiter.withDelay(ms)` for fixed-gap limits. Used by every scraper and crawler.
 
-Rate limiting applies per request. If you set `rateLimitMs: 1000`, every fetch is at least 1000ms apart. If you set `jitterMs: 250`, an additional 0–250ms random delay is added per request. Jitter prevents synchronized bursts when multiple tasks start together. The limiter enforces this before the HTTP call enters the retry executor, so rate limiting happens even on retries — each retry attempt waits its own `minTime` before executing.
+Rate limiting applies per request. If you set `rateLimitMs: 1000`, every fetch is at least 1000ms apart. If you set `jitterMs: 250`, an additional 0–250ms random delay is added per request. Jitter prevents synchronized bursts when multiple tasks start together. The limiter enforces this before the HTTP call enters the retry executor, so rate limiting happens even on retries; each retry attempt waits its own `minTime` before executing.
 
 ## Scrapers
 
@@ -156,16 +156,16 @@ Pure data accessors for HTML (via cheerio) and MediaWiki (via native fetch) that
 
 ### HtmlScraper
 
-Native `fetch` + `cheerio`. Returns `ScrapedPageInterface { url, $, html }`. The `$` field is a live `CheerioAPI` handle — use it exactly as you'd use jQuery on a DOM. No browser engine, no JavaScript execution. For JS-rendered pages, swap the fetch call for a headless driver (Playwright, Puppeteer) and feed the HTML to `cheerio.load()`.
+Native `fetch` + `cheerio`. Returns `ScrapedPageInterface { url, $, html }`. The `$` field is a live `CheerioAPI` handle; use it exactly as you'd use jQuery on a DOM. No browser engine, no JavaScript execution. For JS-rendered pages, swap the fetch call for a headless driver (Playwright, Puppeteer) and feed the HTML to `cheerio.load()`.
 
 ### MediaWikiScraper
 
-Direct `fetch()` calls to the MediaWiki JSON API — no mwn or axios layer. Four operations:
+Direct `fetch()` calls to the MediaWiki JSON API; no mwn or axios layer. Four operations:
 
-- `fetchPage(title)` — single page wikitext
-- `fetchPagesBatch(titles)` — up to 50 pages per API request
-- `fetchCategory(name)` — paginated category members list
-- `fetchAllPages()` — enumerates every article in main namespace via `action=query&list=allpages`
+- `fetchPage(title)`: single page wikitext
+- `fetchPagesBatch(titles)`: up to 50 pages per API request
+- `fetchCategory(name)`: paginated category members list
+- `fetchAllPages()`: enumerates every article in main namespace via `action=query&list=allpages`
 
 The `ScrapeOrchestrator` selects from three modes: explicit `--category` flag → single category; `categories[]` in config → iterate and deduplicate; no categories → `fetchAllPages()`. Rate limiting and jitter applied per-request.
 
@@ -185,7 +185,7 @@ Three regexes control behavior:
 | `delimiter` | Links that match are traversed (followed). Links that don't are ignored entirely. |
 | `target` | Links that match the delimiter AND this pattern are collected as results. Others are traversed but not returned. |
 
-Visited URLs are tracked in a `Set`. All traversals run concurrently via `Promise.all` at each level. Results are deduplicated and sorted with a numeric-aware collator — so `Item-10` sorts after `Item-9`, not between `Item-1` and `Item-2`.
+Visited URLs are tracked in a `Set`. All traversals run concurrently via `Promise.all` at each level. Results are deduplicated and sorted with a numeric-aware collator; so `Item-10` sorts after `Item-9`, not between `Item-1` and `Item-2`.
 
 ## Source map
 
@@ -196,14 +196,14 @@ Complete index of every source file, its exported symbols, and the PathRipper or
 | `src/pipeline/Pipeline.ts` | `Pipeline<TState>` | PathRipper `Transformer` |
 | `src/modules/http/ErrorClassifier.ts` | `ErrorClassifier`, `ErrorCategory` | TORUS `errorClassifier.ts` |
 | `src/modules/http/RetryExecutor.ts` | `RetryExecutor` | TORUS `RetryPolicyNode` |
-| `src/modules/http/RateLimiter.ts` | `RateLimiter` | New — wraps `bottleneck` |
+| `src/modules/http/RateLimiter.ts` | `RateLimiter` | New: wraps `bottleneck` |
 | `src/modules/logger/Logger.ts` | `Logger` | Torreya `@torreya/logger` |
 | `src/scrapers/HtmlScraper.ts` | `HtmlScraper` | PathRipper `fetchPage`, cheerio replaces JSDOM |
-| `src/scrapers/MediaWikiScraper.ts` | `MediaWikiScraper` | New — native `fetch()` to MediaWiki JSON API |
-| `src/scrapers/WikitextParser.ts` | `WikitextParser` | New — `wtf_wikipedia` |
+| `src/scrapers/MediaWikiScraper.ts` | `MediaWikiScraper` | New: native `fetch()` to MediaWiki JSON API |
+| `src/scrapers/WikitextParser.ts` | `WikitextParser` | New: `wtf_wikipedia` |
 | `src/crawlers/LinkLister.ts` | `LinkLister` | PathRipper `linkLister/index.js` |
-| `src/orchestrators/ScrapeOrchestrator.ts` | `ScrapeOrchestrator` | New — pipeline orchestration, three-mode wiki scrape |
-| `src/registry/TaskRegistry.ts` | `TaskRegistry` | New — plugin registration and dynamic loading |
-| `src/registry/PipelineState.ts` | `PipelineState` | New — typed state bridge between scrapers and plugins |
-| `src/config/RipperConfig.ts` | `RipperConfig` | New — replaces hardcoded `config.js` |
-| `src/cli/cli.ts` | `ripperoni` CLI | New — `commander` |
+| `src/orchestrators/ScrapeOrchestrator.ts` | `ScrapeOrchestrator` | New: pipeline orchestration, three-mode wiki scrape |
+| `src/registry/TaskRegistry.ts` | `TaskRegistry` | New: plugin registration and dynamic loading |
+| `src/registry/PipelineState.ts` | `PipelineState` | New: typed state bridge between scrapers and plugins |
+| `src/config/RipperConfig.ts` | `RipperConfig` | New: replaces hardcoded `config.js` |
+| `src/cli/cli.ts` | `ripperoni` CLI | New: `commander` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,18 +36,32 @@ Typed async middleware chain where every task receives `(next, state)` and advan
 
 The core architecture is a typed middleware chain inherited from PathRipper's `Transformer` class, rewritten in TypeScript. Every task receives `(next, state)`. Calling `next()` advances to the next task; not calling it terminates the chain.
 
+Problem being solved: Ripperoni scrapes multiple pages from multiple sources with domain-specific extraction logic per site. The pipeline decouples HTTP machinery from parsing logic. A task either advances the queue or terminates early to skip remaining tasks (e.g. if parsing fails, don't write to disk). The same `state` object flows through the entire chain; no copying, no callbacks collecting results.
+
+State mutation contract: `TState extends Record<string, unknown>`. Tasks mutate the state reference directly. The pipeline passes the same object to every task in sequence; the caller receives the mutated reference after `execute()` returns. This avoids async callback nesting and lets each task read what previous tasks wrote.
+
+Early termination semantics: A task that doesn't call `await next()` stops the chain. This is how you halt processing without throwing: set an error flag on state, skip `next()`, and the write task sees the flag and decides whether to write. The pipeline doesn't inspect state; it just runs whatever tasks called `next()` in their callbacks.
+
 ```mermaid
 sequenceDiagram
     participant Caller
     participant Pipeline
-    participant ParseTask as <targetId>:parse (plugin)
-    participant WriteTask as write-to-disk (orchestrator)
+    participant FetchTask as html:fetch
+    participant ParseTask as mysite:parse (plugin)
+    participant WriteTask as json:write
 
-    Caller->>Pipeline: execute(PipelineState)
+    Caller->>Pipeline: execute(state)
+    Pipeline->>FetchTask: (next, state)
+    FetchTask->>FetchTask: fetch URL, load HTML
+    FetchTask->>FetchTask: state.input.html = body
+    FetchTask->>Pipeline: await next()
     Pipeline->>ParseTask: (next, state)
-    ParseTask-->>Pipeline: state.output set
+    ParseTask->>ParseTask: $ = cheerio(html)
+    ParseTask->>ParseTask: state.output = {...}
+    ParseTask->>Pipeline: await next()
     Pipeline->>WriteTask: (next, state)
-    WriteTask-->>Pipeline: file written
+    WriteTask->>WriteTask: write state.output to disk
+    WriteTask->>Pipeline: await next()
     Pipeline-->>Caller: state
 ```
 
@@ -73,21 +87,32 @@ type TaskFnType<TState> = (next: NextFnType, state: TState) => Promise<void>
 
 `TState` must extend `Record<string, unknown>`. Tasks mutate state directly — the pipeline passes the same reference through the chain.
 
+Why this matters: If a task decides to bail out (malformed HTML, missing required field), it skips `await next()` and the write task never runs. You don't need error handling middleware; you just don't call `next()`. This is simpler than try/catch chains and keeps the control flow local to each task.
+
 ## HTTP machinery
 
 Three composable classes — `RateLimiter`, `RetryExecutor`, and `ErrorClassifier` — form the HTTP stack, each injected independently.
 
-Three classes form the HTTP stack, ported from TORUS (Topological Orchestration Runtime for Unified Streaming). They're independent of each other and compose by injection.
+Problem being solved: HTTP is unreliable. Networks fail. Servers get overloaded and 429. Caches go stale. When Ripperoni fetches a page, it needs to retry transient errors but give up on permanent ones, respect `Retry-After` headers, and throttle to avoid hammering the target server. The three-class stack keeps these concerns separate so you can swap implementations or compose them differently in tests.
+
+Error propagation rules: An error enters `ErrorClassifier` which examines the error object or HTTP status code. If the classifier says it's retryable (`NETWORK`, `TIMEOUT`, `THROTTLED`, `TRANSIENT`), the error goes back to `RetryExecutor` which waits and tries again. If the classifier says it's permanent (`PERMANENT`, `VALIDATION`, `RESOURCE`), the error is thrown immediately. A 404 is permanent (throw immediately). A 500 is transient (retry). A 429 is throttled (retry with `Retry-After` delay).
+
+Cache and retry interaction: The cache sits upstream of this stack. A cache hit bypasses the entire HTTP machinery — the cached body is returned directly to the pipeline. A cache miss enters the HTTP stack: rate limiter makes you wait, then RetryExecutor calls fetch, then ErrorClassifier decides if we retry. On success, the response is cached. So the first fetch of a URL pays the full HTTP + retry cost; the second fetch hits cache and costs almost nothing.
 
 ```mermaid
 graph LR
-    Request[fetch call] --> RateLimiter
-    RateLimiter --> RetryExecutor
-    RetryExecutor --> ErrorClassifier
-    ErrorClassifier -->|retryable| RetryExecutor
-    ErrorClassifier -->|permanent| Throw[throw]
-    RetryExecutor -->|max attempts| Throw
-    RetryExecutor -->|success| Response
+    Request[fetch call] --> RateLimit["rate limiter
+    (wait minTime)"]
+    RateLimit --> Retry["retry executor
+    attempt 1"]
+    Retry --> HTTP["HTTP GET"]
+    HTTP -->|error| Classify["error classifier
+    (read status/code)"]
+    Classify -->|retryable| Wait["wait backoff
+    ± jitter"]
+    Wait --> Retry
+    Classify -->|permanent| Throw[throw]
+    HTTP -->|success| Response
 ```
 
 ### ErrorClassifier
@@ -104,9 +129,13 @@ Classifies errors into seven categories. Only NETWORK, THROTTLED, TIMEOUT, and T
 | `VALIDATION` | no | `TypeError`, `SyntaxError`, `ValidationError` |
 | `RESOURCE` | no | `ENOMEM`, `ENOSPC` |
 
+Retry-After handling: When a server returns HTTP 429 with a `Retry-After` header (in seconds or RFC 1123 date), ErrorClassifier extracts the value and returns it as a `backoffHint`. RetryExecutor uses this hint as the delay before the next attempt, overriding the exponential backoff curve. If `Retry-After` is malformed or missing, the backoff falls back to the exponential schedule. This prevents hammering a throttled server while respecting its explicit guidance.
+
 ### RetryExecutor
 
 Wraps any async function. On retryable error: waits, retries up to `maxAttempts`. Delay uses exponential backoff with ±10% decorrelated jitter to avoid thundering herd.
+
+Backoff formula: `delay = min(baseDelayMs * 2^attempt, maxDelayMs) ± jitter`. For `baseDelayMs=500, multiplier=2, maxDelayMs=30000`: attempt 0 (no retry) = fail immediately, attempt 1 = ~500ms, attempt 2 = ~1000ms, attempt 3 = ~2000ms, then capped at 30s. Jitter is random ±10% to prevent multiple clients from retrying in lockstep and causing a thundering herd.
 
 | Option | Default | Description |
 |--------|---------|-------------|
@@ -118,6 +147,8 @@ Wraps any async function. On retryable error: waits, retries up to `maxAttempts`
 ### RateLimiter
 
 Token-bucket backed by `bottleneck`. Factory methods: `RateLimiter.perSecond(n)` for throughput-based limits, `RateLimiter.withDelay(ms)` for fixed-gap limits. Used by every scraper and crawler.
+
+Rate limiting applies per request. If you set `rateLimitMs: 1000`, every fetch is at least 1000ms apart. If you set `jitterMs: 250`, an additional 0–250ms random delay is added per request. Jitter prevents synchronized bursts when multiple tasks start together. The limiter enforces this before the HTTP call enters the retry executor, so rate limiting happens even on retries — each retry attempt waits its own `minTime` before executing.
 
 ## Scrapers
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ npm run build
 ## Create a config
 
 Copy `ripperoni.config.example.json` to `ripperoni.config.json` and edit.
-The unprefixed file is gitignored — it holds your real targets.
+The unprefixed file is gitignored; it holds your real targets.
 
 ```json
 {
@@ -87,5 +87,5 @@ TaskRegistry.register('my-target:parse', async (next, state) => {
 
 ## Where to look next
 
-- [Architecture](./architecture) — pipeline, HTTP machinery, scrapers, source map
-- [Roadmap](./roadmap) — what shipped, what's planned
+- [Architecture](./architecture): pipeline, HTTP machinery, scrapers, source map
+- [Roadmap](./roadmap): what shipped, what's planned

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ title: Ripperoni
 <div style="text-align:center;padding:2rem 0 1rem">
   <img src="/ripperoni.png" alt="Ripperoni" style="max-width:120px;margin:0 auto 1rem" />
   <h1 style="font-size:2.5rem;font-weight:700;margin:0.5rem 0">Ripperoni</h1>
-  <p style="font-size:1.2rem;color:var(--vp-c-text-2);max-width:600px;margin:0 auto 1.5rem">Web ingestion engine — slices wikis, sites, and URL lists into JSON records, one page at a time. Point it at a wiki, a site, or a list of URLs and it hands you the meat.</p>
+  <p style="font-size:1.2rem;color:var(--vp-c-text-2);max-width:600px;margin:0 auto 1.5rem">Web ingestion engine: slices wikis, sites, and URL lists into JSON records, one page at a time. Point it at a wiki, a site, or a list of URLs and it hands you the meat.</p>
   <div style="display:flex;gap:0.75rem;justify-content:center;flex-wrap:wrap;margin-bottom:2rem">
     <a href="/Ripperoni/getting-started" class="VPButton medium brand" style="text-decoration:none;padding:0.5rem 1.25rem;border-radius:4px;background:var(--vp-button-brand-bg);color:var(--vp-button-brand-text);font-weight:500">Get started</a>
     <a href="/Ripperoni/walk-through" class="VPButton medium brand" style="text-decoration:none;padding:0.5rem 1.25rem;border-radius:4px;background:var(--vp-button-brand-bg);color:var(--vp-button-brand-text);font-weight:500">Walk-through</a>
@@ -19,7 +19,7 @@ Point it at a domain. Hand it a plugin. It fetches pages, runs your plugin again
 
 - **Typed pipeline.** Middleware task queue with `async (next, state) => void` signature. Add, compose, and reorder tasks without touching anything else.
 - **HTML scraper.** Native fetch + cheerio. No JSDOM, no headless browser. Returns a `CheerioAPI` handle so you work with familiar selectors.
-- **MediaWiki scraper.** Native fetch against the MediaWiki JSON API. Three modes — single category, categories array, or full-wiki enumeration. Batch wikitext fetch, redirect resolution, `wtf_wikipedia` infobox extraction.
+- **MediaWiki scraper.** Native fetch against the MediaWiki JSON API. Three modes: single category, categories array, or full-wiki enumeration. Batch wikitext fetch, redirect resolution, `wtf_wikipedia` infobox extraction.
 - **Link crawler.** Recursively crawls pages matching domain/target/delimiter regexes. Deduplicates, sorts naturally, respects rate limit.
 - **Retry + backoff.** Exponential backoff with decorrelated jitter. Respects `Retry-After` headers. Classifies errors as `NETWORK / THROTTLED / TIMEOUT / TRANSIENT / PERMANENT`.
 
@@ -32,6 +32,6 @@ cd Ripperoni && npm install && npm run build
 
 ## Where to look next
 
-- [Walk-through](./walk-through) — end-to-end example with a real URL, config, plugin, and output record
-- [Getting started](./getting-started) — install and first run
-- [Architecture](./architecture) — pipeline phases, package boundaries, extension points
+- [Walk-through](./walk-through): end-to-end example with a real URL, config, plugin, and output record
+- [Getting started](./getting-started): install and first run
+- [Architecture](./architecture): pipeline phases, package boundaries, extension points

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,7 +17,7 @@ v2.0.0 is a ground-up rewrite of the 2019 PathRipper. The core pipeline, HTML sc
 | Concurrent pipeline | live | `ConcurrentPipeline.create(pipeline, concurrency)` fans N pages through the same pipeline simultaneously with a semaphore cap. |
 | Task registry | live | `TaskRegistry.register(name, fn)` + dynamic plugin loading via `pipeline: ["my-target:parse"]` in config. Plugins are `.js` files loaded at runtime. |
 | Checkpoint + resume | live | Already-written slugs are detected at run start and skipped. Failed pages are written to `failures.json`; pass `--resume-failures` to retry only those. |
-| Config schema validation | live | AJV validates the config at load time. `RipperConfig.load(path)` throws with the exact field path on any violation — malformed configs fail fast and loudly. |
+| Config schema validation | live | AJV validates the config at load time. `RipperConfig.load(path)` throws with the exact field path on any violation; malformed configs fail fast and loudly. |
 
 ## Planned
 

--- a/docs/usage/cache.md
+++ b/docs/usage/cache.md
@@ -7,6 +7,10 @@ title: Cache
 
 `ScraperCache` is a sharded, content-addressed pointer cache. It stores what was fetched so subsequent runs skip the network.
 
+Problem being solved: Iterating on a parse plugin is slow if every run re-fetches all pages. The cache saves every HTTP response to disk so the next run can replay from cache without hitting the network. This makes the edit-test cycle fast: change your parse plugin, rerun, hit cache, extract in seconds instead of minutes.
+
+Sharding rationale: Without sharding, a cache directory with 10,000 entries becomes a single flat directory where `readdir()` gets slow (hundreds of milliseconds per operation on some filesystems). By sharding into subdirectories using the first two hex characters of the cache key, each subdirectory holds ~256 entries. A `readdir()` of 256 files is fast; a `readdir()` of 10,000 is not. The two-character prefix is a sweet spot: enough entropy to spread load but not so granular that you end up with thousands of single-file directories.
+
 ## How it works
 
 The cache stores two things per entry:
@@ -33,6 +37,10 @@ The key is derived from the request: HTTP method + URL, hashed to a fixed-length
 | `write-only` | no | yes | Always fetch; always cache. Refreshes stale entries. |
 | `off` | no | no | No caching. Every run hits the network. |
 
+Cache hit and rate limiting: On a cache hit, the cached body is returned directly without entering the rate limiter. This is intentional: rate limiting protects the remote server, not your disk. Reading from disk is free and fast. However, cache hits still enter the pipeline — your parse task runs, extraction happens, and files are written.
+
+Concurrent write semantics: If two tasks attempt to cache the same URL simultaneously, the last write wins (second task's body overwrites the first). There's no lock or transaction around cache writes. For a single orchestrator run this isn't an issue because each URL is processed once per concurrency slot. If you run multiple Ripperoni instances against the same cache directory, they'll interfere with each other; use separate cache directories per instance or disable the cache for concurrent runners.
+
 ## TTL
 
 ```json
@@ -46,6 +54,8 @@ The key is derived from the request: HTTP method + URL, hashed to a fixed-length
 `ttlMs` is in milliseconds. An entry older than `ttlMs` is treated as a miss on read — the fetcher goes to the network and overwrites the entry. Omit `ttlMs` for no expiration.
 
 `86400000` = 24 hours. `604800000` = 7 days.
+
+Stale-entry behavior: When you read a cached entry, its timestamp is checked against the current time. If `now - fetchedAt > ttlMs`, the entry is treated as a cache miss. The fetcher re-fetches the URL and overwrites the old entry with a new `fetchedAt` timestamp. The old file is replaced atomically. This is called "write-through" expiration: you only refresh entries when you try to use them, not on a background schedule.
 
 ## LRU eviction
 
@@ -89,6 +99,10 @@ output/.cache/aonprd/
 
 The shard prefix keeps each subdirectory small enough that `readdir()` stays fast even with tens of thousands of entries.
 
+## Read-only mode failure modes
+
+When `mode: "read-only"` is set, the cache will not write new entries. If a fetch request for a URL that isn't in the cache occurs, the fetcher throws an error immediately — there's no fallback to the network. This is useful for offline development where you've pre-cached a known set of URLs and want to catch typos in your config (a new URL will surface the error immediately, not silently hit the network).
+
 ## Clearing the cache
 
 Delete the cache directory:
@@ -97,7 +111,7 @@ Delete the cache directory:
 rm -rf ./output/.cache/aonprd
 ```
 
-Or switch `mode` to `write-only` for one run to refresh all entries.
+Or switch `mode` to `write-only` for one run to refresh all entries. In `write-only` mode, every URL is fetched fresh and cached, overwriting any stale entries. This is faster than deleting the directory if you want to do a full refresh without losing directory structure.
 
 ## Related
 

--- a/docs/usage/cache.md
+++ b/docs/usage/cache.md
@@ -32,12 +32,12 @@ The key is derived from the request: HTTP method + URL, hashed to a fixed-length
 
 | Mode | Reads | Writes | When to use |
 |------|-------|--------|-------------|
-| `read-write` | yes | yes | Normal development — skip the network on subsequent runs. |
+| `read-write` | yes | yes | Normal development; skip the network on subsequent runs. |
 | `read-only` | yes | no | Replay from cache only. Fails if a URL is not cached. Useful for offline reproduction. |
 | `write-only` | no | yes | Always fetch; always cache. Refreshes stale entries. |
 | `off` | no | no | No caching. Every run hits the network. |
 
-Cache hit and rate limiting: On a cache hit, the cached body is returned directly without entering the rate limiter. This is intentional: rate limiting protects the remote server, not your disk. Reading from disk is free and fast. However, cache hits still enter the pipeline — your parse task runs, extraction happens, and files are written.
+Cache hit and rate limiting: On a cache hit, the cached body is returned directly without entering the rate limiter. This is intentional: rate limiting protects the remote server, not your disk. Reading from disk is free and fast. However, cache hits still enter the pipeline; your parse task runs, extraction happens, and files are written.
 
 Concurrent write semantics: If two tasks attempt to cache the same URL simultaneously, the last write wins (second task's body overwrites the first). There's no lock or transaction around cache writes. For a single orchestrator run this isn't an issue because each URL is processed once per concurrency slot. If you run multiple Ripperoni instances against the same cache directory, they'll interfere with each other; use separate cache directories per instance or disable the cache for concurrent runners.
 
@@ -51,7 +51,7 @@ Concurrent write semantics: If two tasks attempt to cache the same URL simultane
 }
 ```
 
-`ttlMs` is in milliseconds. An entry older than `ttlMs` is treated as a miss on read — the fetcher goes to the network and overwrites the entry. Omit `ttlMs` for no expiration.
+`ttlMs` is in milliseconds. An entry older than `ttlMs` is treated as a miss on read; the fetcher goes to the network and overwrites the entry. Omit `ttlMs` for no expiration.
 
 `86400000` = 24 hours. `604800000` = 7 days.
 
@@ -59,11 +59,11 @@ Stale-entry behavior: When you read a cached entry, its timestamp is checked aga
 
 ## LRU eviction
 
-When `maxEntries` is set (programmatic use only — not in the JSON config schema), the cache evicts the oldest entries by `fetchedAt` on write. The JSON config only exposes `dir`, `mode`, and `ttlMs`.
+When `maxEntries` is set (programmatic use only; not in the JSON config schema), the cache evicts the oldest entries by `fetchedAt` on write. The JSON config only exposes `dir`, `mode`, and `ttlMs`.
 
 ## Cache key
 
-The key is derived from `{ method, url }` — the same URL always maps to the same key. Ripperoni only GETs, so in practice the key is the URL hash.
+The key is derived from `{ method, url }`; the same URL always maps to the same key. Ripperoni only GETs, so in practice the key is the URL hash.
 
 ```ts
 const key = ScraperCache.keyFor({ method: 'GET', url });
@@ -71,19 +71,19 @@ const key = ScraperCache.keyFor({ method: 'GET', url });
 
 ## Workflow
 
-First run — cache cold:
+First run; cache cold:
 
 ```
 html:fetch → cache miss → HTTP GET → store in cache → hand HTML to parse task
 ```
 
-Subsequent runs — cache warm:
+Subsequent runs; cache warm:
 
 ```
 html:fetch → cache hit → return cached HTML → hand HTML to parse task
 ```
 
-Network is never touched on a cache hit. This makes iterating on your parse plugin fast — change the plugin, rerun, no waiting.
+Network is never touched on a cache hit. This makes iterating on your parse plugin fast; change the plugin, rerun, no waiting.
 
 ## Cache directory structure
 
@@ -101,7 +101,7 @@ The shard prefix keeps each subdirectory small enough that `readdir()` stays fas
 
 ## Read-only mode failure modes
 
-When `mode: "read-only"` is set, the cache will not write new entries. If a fetch request for a URL that isn't in the cache occurs, the fetcher throws an error immediately — there's no fallback to the network. This is useful for offline development where you've pre-cached a known set of URLs and want to catch typos in your config (a new URL will surface the error immediately, not silently hit the network).
+When `mode: "read-only"` is set, the cache will not write new entries. If a fetch request for a URL that isn't in the cache occurs, the fetcher throws an error immediately; there's no fallback to the network. This is useful for offline development where you've pre-cached a known set of URLs and want to catch typos in your config (a new URL will surface the error immediately, not silently hit the network).
 
 ## Clearing the cache
 
@@ -115,5 +115,5 @@ Or switch `mode` to `write-only` for one run to refresh all entries. In `write-o
 
 ## Related
 
-- [Scrapers](./scrapers) — how HtmlScraper uses the cache
-- [Configuration](./configuration) — cache config schema
+- [Scrapers](./scrapers); how HtmlScraper uses the cache
+- [Configuration](./configuration); cache config schema

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -61,6 +61,32 @@ Each key is a target name (e.g. `"aonprd"`). Value is a target config.
 | `cache` | CacheConfig | — | See [Cache](./cache). |
 | `crawler` | CrawlerConfig | — | Inline crawler config for this target. |
 
+Concurrency bound rationale: Concurrency is clamped to 1–32 to prevent runaway parallelism. At concurrency 32, you can have 32 HTTP requests in flight simultaneously. This is usually enough to saturate downstream bandwidth and quickly hit many servers' rate limits. Beyond 32, the marginal benefit drops and the risk of getting blocked increases. If you need more parallelism, run multiple Ripperoni instances.
+
+Validation timing: When validation errors surface depends on your schema. If your `outputSchema` has required fields and your plugin sets `output: {}`, the validation fails when `json:write` tries to serialize the record. The error is handled per `onSchemaError`: `"halt"` throws and stops the run, `"skip"` logs a warning and skips the file, `"warn"` logs and writes anyway.
+
+Retry × concurrency worst-case: If every fetch in a batch of `concurrency` tasks encounters a transient error and retries to `maxDelayMs` (30 seconds), the batch duration could be 30+ seconds. Total run time is `ceil(N / concurrency) * maxRetryTime`. For 1000 URLs with concurrency 10: `ceil(1000/10) * 30s = 100 * 30 = 50 minutes` in the absolute worst case (every fetch fails and retries max times). In practice, cache hits and successful first attempts keep this much lower.
+
+Field mapping worked example: After your plugin extracts a record, `mapping` renames fields without touching your code:
+
+```json
+"targets": {
+  "aonprd": {
+    "pipeline": ["html:fetch", "aonprd:parse", "json:write"],
+    "mapping": {
+      "name": "title",
+      "description": "desc"
+    }
+  }
+}
+```
+
+If your plugin sets `state.output = { name: "Fireball", description: "Conjures..." }`, the written file gets `{ title: "Fireball", desc: "Conjures...", ... }`. The original fields are gone; only the mapped names appear in the JSON.
+
+Cache and retry interaction: The cache sits upstream of retry logic. A cache hit means no retry-executor is invoked (no exponential backoff). A cache miss triggers the full HTTP stack: rate limiter, retry executor with backoff, then cache write on success. The first fetch of a URL can take up to `maxRetryTime`; the second hit takes microseconds (cache read).
+
+Validation errors surface at first write. If your plugin produces invalid output, the first file write detects it. All subsequent pages from the same target go through the same validator, so you'll see the full picture of validation failures quickly (don't run all 1000 pages to find out your schema is wrong).
+
 ### Example
 
 ```json

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -47,19 +47,19 @@ Each key is a target name (e.g. `"aonprd"`). Value is a target config.
 
 | Key | Type | Default | Notes |
 |-----|------|---------|-------|
-| `rateLimitMs` | integer ≥ 0 | — | Minimum milliseconds between requests. |
-| `jitterMs` | integer ≥ 0 | — | Random jitter added on top of `rateLimitMs`. Applied per request. |
-| `maxRetries` | integer 0–10 | — | Retry attempts on transient errors. |
-| `retryBaseDelayMs` | integer ≥ 100 | — | Base delay for retry backoff. |
-| `retryMaxDelayMs` | integer ≥ 1000 | — | Backoff ceiling. |
+| `rateLimitMs` | integer ≥ 0 |  | Minimum milliseconds between requests. |
+| `jitterMs` | integer ≥ 0 |  | Random jitter added on top of `rateLimitMs`. Applied per request. |
+| `maxRetries` | integer 0–10 |  | Retry attempts on transient errors. |
+| `retryBaseDelayMs` | integer ≥ 100 |  | Base delay for retry backoff. |
+| `retryMaxDelayMs` | integer ≥ 1000 |  | Backoff ceiling. |
 | `concurrency` | integer 1–32 | `1` | Parallel fetch/process slots. |
-| `maxPages` | integer ≥ 0 | — | Stop after processing this many pages. |
-| `headers` | object | — | Additional HTTP headers. Include `User-Agent`. |
-| `outputSchema` | string | — | Path to a JSON Schema file. Records that fail validation are handled per `onSchemaError`. |
-| `onSchemaError` | `"halt"` \| `"skip"` \| `"warn"` | — | What to do when a record fails schema validation. |
-| `mapping` | object | — | Field-rename map applied after plugin output. |
-| `cache` | CacheConfig | — | See [Cache](./cache). |
-| `crawler` | CrawlerConfig | — | Inline crawler config for this target. |
+| `maxPages` | integer ≥ 0 |  | Stop after processing this many pages. |
+| `headers` | object |  | Additional HTTP headers. Include `User-Agent`. |
+| `outputSchema` | string |  | Path to a JSON Schema file. Records that fail validation are handled per `onSchemaError`. |
+| `onSchemaError` | `"halt"` \| `"skip"` \| `"warn"` |  | What to do when a record fails schema validation. |
+| `mapping` | object |  | Field-rename map applied after plugin output. |
+| `cache` | CacheConfig |  | See [Cache](./cache). |
+| `crawler` | CrawlerConfig |  | Inline crawler config for this target. |
 
 Concurrency bound rationale: Concurrency is clamped to 1–32 to prevent runaway parallelism. At concurrency 32, you can have 32 HTTP requests in flight simultaneously. This is usually enough to saturate downstream bandwidth and quickly hit many servers' rate limits. Beyond 32, the marginal benefit drops and the risk of getting blocked increases. If you need more parallelism, run multiple Ripperoni instances.
 
@@ -170,8 +170,8 @@ See [Cache](./cache) for sharding, eviction, and TTL behavior.
 
 ## Related
 
-- [Pipeline](./pipeline) — task registration and state shape
-- [Scrapers](./scrapers) — HtmlScraper vs MediaWikiScraper
-- [MediaWiki](./mediawiki) — three enumeration modes
-- [Crawler](./crawler) — LinkLister behavior
-- [Cache](./cache) — read/write modes, TTL, eviction
+- [Pipeline](./pipeline); task registration and state shape
+- [Scrapers](./scrapers); HtmlScraper vs MediaWikiScraper
+- [MediaWiki](./mediawiki); three enumeration modes
+- [Crawler](./crawler); LinkLister behavior
+- [Cache](./cache); read/write modes, TTL, eviction

--- a/docs/usage/crawler.md
+++ b/docs/usage/crawler.md
@@ -9,6 +9,14 @@ title: Crawler
 
 ## Three regexes
 
+Problem being solved: You want to crawl a site to build a URL list for scraping, but you don't want the crawler to follow every link it encounters. You want it to traverse category pages (to find all items) but only collect individual item pages (the URLs you'll scrape). Three regexes give you fine-grained control over both traversal and collection.
+
+Three-regex decision tree: For each link the crawler finds, it applies three filters in order:
+
+1. **Domain filter**: Does the link match `domain`? If no, ignore it entirely (don't traverse, don't collect).
+2. **Delimiter filter**: Does the link match `domain` AND `delimiter`? If yes, add it to the frontier (traverse it). If no, skip it (don't follow).
+3. **Target filter**: Does the link match `domain` AND `delimiter` AND `target`? If yes, add it to the results. If no, ignore it (traverse it but don't collect).
+
 ```json
 {
   "crawlers": {
@@ -35,6 +43,8 @@ In the example above:
 - Links to `Feats.aspx?ID=\d+` are collected — they're detail pages.
 - The starting URL itself is traversed first.
 
+Note: Every link must match `domain` to be considered. If a link doesn't match `domain`, it's not evaluated against `delimiter` or `target` at all. This keeps crawls confined to their target site.
+
 ## Visited and collected sets
 
 Two internal sets track state:
@@ -43,11 +53,15 @@ Two internal sets track state:
 
 A URL can be traversed without being collected. The crawler follows list pages but only hands back detail pages.
 
-## Concurrency
+## Concurrency model
 
-All traversals at a given depth level run concurrently via `Promise.all`. Depth-first is not guaranteed — the crawler processes all frontier URLs in parallel before moving to the next level.
+Traversal is breadth-first, not depth-first. All URLs at a given frontier depth are fetched and parsed concurrently via `Promise.all`. The crawler collects all links from depth 0, then all links from depth 1, then depth 2, etc. This means you discover broad categories of results before drilling deep into any one.
 
-`rateLimitMs` and `jitterMs` apply per request, same as scrapers.
+`rateLimitMs` and `jitterMs` apply per request, same as scrapers. Even though multiple URLs are fetched in parallel, each still waits its turn in the rate limiter. If `rateLimitMs: 500` and concurrency is 10, you're still issuing requests 500ms apart; the concurrency is about how many are in flight (buffered in the rate limiter queue), not about how fast they're issued.
+
+## Revisit semantics
+
+The crawler tracks `#visited` (URLs already traversed) and `#collected` (URLs in results). Once a URL is added to `visited`, revisiting it from another depth is skipped — no duplicate fetches. This prevents infinite loops if your site has bidirectional links. A URL can be traversed without being collected (list pages are traversed but not returned). A URL is collected only if it matches all three regexes.
 
 ## maxPages
 
@@ -55,11 +69,13 @@ All traversals at a given depth level run concurrently via `Promise.all`. Depth-
 "maxPages": 500
 ```
 
-Hard ceiling on collected results. The crawl stops when this many URLs have been matched as results, even if there are more frontier URLs to follow.
+Hard ceiling on collected results. The crawl stops as soon as this many URLs have been matched as results, even if there are more frontier URLs to follow. The crawler doesn't keep searching after hitting the limit; the next traversal iteration will discover that `results.size >= maxPages` and halt.
 
 ## Deduplication and sorting
 
-Results are deduplicated automatically — the same URL appearing at multiple traversal depths is collected once.
+Results are deduplicated automatically — the same URL appearing at multiple traversal depths is collected once. The dedupe happens at collection time: if URL A matches `target` at depth 0 and again at depth 2, it's added to results on the first match; the second match sees it's already in `collected` and skips it.
+
+Numeric collation rationale: By default, `Item-10` sorts before `Item-2` because string comparison is lexicographic (`"1" < "2"`). Numeric-aware collation sorts by the numeric value of each segment, so `Item-2` then `Item-10`. This makes URL lists sortable and diff-able across runs — you can `diff before.json after.json` and see only actual changes, not reordering artifacts.
 
 Sorting uses a numeric-aware collator: `Item-10` sorts after `Item-9`, not between `Item-1` and `Item-2`. Consistent ordering makes the output list diff-able.
 

--- a/docs/usage/crawler.md
+++ b/docs/usage/crawler.md
@@ -5,7 +5,7 @@ title: Crawler
 
 # Crawler
 
-`LinkLister` recursively follows links from one or more starting URLs and returns the set of URLs that match your target pattern. It doesn't scrape content — it builds a URL list. You hand that list to a scraper.
+`LinkLister` recursively follows links from one or more starting URLs and returns the set of URLs that match your target pattern. It doesn't scrape content; it builds a URL list. You hand that list to a scraper.
 
 ## Three regexes
 
@@ -39,8 +39,8 @@ Three-regex decision tree: For each link the crawler finds, it applies three fil
 
 In the example above:
 - Any link to a different domain is ignored.
-- Links to `Feats.aspx` (without query string) are traversed — they're list pages.
-- Links to `Feats.aspx?ID=\d+` are collected — they're detail pages.
+- Links to `Feats.aspx` (without query string) are traversed: they're list pages.
+- Links to `Feats.aspx?ID=\d+` are collected; they're detail pages.
 - The starting URL itself is traversed first.
 
 Note: Every link must match `domain` to be considered. If a link doesn't match `domain`, it's not evaluated against `delimiter` or `target` at all. This keeps crawls confined to their target site.
@@ -48,8 +48,8 @@ Note: Every link must match `domain` to be considered. If a link doesn't match `
 ## Visited and collected sets
 
 Two internal sets track state:
-- `#visited` — URLs already traversed (prevents loops).
-- `#collected` — URLs matched as results.
+- `#visited`: URLs already traversed (prevents loops).
+- `#collected`: URLs matched as results.
 
 A URL can be traversed without being collected. The crawler follows list pages but only hands back detail pages.
 
@@ -61,7 +61,7 @@ Traversal is breadth-first, not depth-first. All URLs at a given frontier depth 
 
 ## Revisit semantics
 
-The crawler tracks `#visited` (URLs already traversed) and `#collected` (URLs in results). Once a URL is added to `visited`, revisiting it from another depth is skipped — no duplicate fetches. This prevents infinite loops if your site has bidirectional links. A URL can be traversed without being collected (list pages are traversed but not returned). A URL is collected only if it matches all three regexes.
+The crawler tracks `#visited` (URLs already traversed) and `#collected` (URLs in results). Once a URL is added to `visited`, revisiting it from another depth is skipped; no duplicate fetches. This prevents infinite loops if your site has bidirectional links. A URL can be traversed without being collected (list pages are traversed but not returned). A URL is collected only if it matches all three regexes.
 
 ## maxPages
 
@@ -73,9 +73,9 @@ Hard ceiling on collected results. The crawl stops as soon as this many URLs hav
 
 ## Deduplication and sorting
 
-Results are deduplicated automatically — the same URL appearing at multiple traversal depths is collected once. The dedupe happens at collection time: if URL A matches `target` at depth 0 and again at depth 2, it's added to results on the first match; the second match sees it's already in `collected` and skips it.
+Results are deduplicated automatically; the same URL appearing at multiple traversal depths is collected once. The dedupe happens at collection time: if URL A matches `target` at depth 0 and again at depth 2, it's added to results on the first match; the second match sees it's already in `collected` and skips it.
 
-Numeric collation rationale: By default, `Item-10` sorts before `Item-2` because string comparison is lexicographic (`"1" < "2"`). Numeric-aware collation sorts by the numeric value of each segment, so `Item-2` then `Item-10`. This makes URL lists sortable and diff-able across runs — you can `diff before.json after.json` and see only actual changes, not reordering artifacts.
+Numeric collation rationale: By default, `Item-10` sorts before `Item-2` because string comparison is lexicographic (`"1" < "2"`). Numeric-aware collation sorts by the numeric value of each segment, so `Item-2` then `Item-10`. This makes URL lists sortable and diff-able across runs; you can `diff before.json after.json` and see only actual changes, not reordering artifacts.
 
 Sorting uses a numeric-aware collator: `Item-10` sorts after `Item-9`, not between `Item-1` and `Item-2`. Consistent ordering makes the output list diff-able.
 
@@ -83,7 +83,7 @@ Sorting uses a numeric-aware collator: `Item-10` sorts after `Item-9`, not betwe
 
 Two ways to configure a crawler:
 
-**Top-level** (`crawlers` block) — runs as a standalone job, produces a URL list:
+**Top-level** (`crawlers` block); runs as a standalone job, produces a URL list:
 
 ```json
 {
@@ -99,7 +99,7 @@ Two ways to configure a crawler:
 }
 ```
 
-**Inline** (`targets[].crawler`) — the scrape target crawls before it fetches:
+**Inline** (`targets[].crawler`); the scrape target crawls before it fetches:
 
 ```json
 {
@@ -123,6 +123,6 @@ In the inline case, the orchestrator runs the crawler first, then scrapes each c
 
 ## Related
 
-- [Configuration](./configuration) — crawler config schema
-- [Scrapers](./scrapers) — what happens after the crawler hands back URLs
-- [Cache](./cache) — crawler requests go through the rate limiter but not the cache
+- [Configuration](./configuration); crawler config schema
+- [Scrapers](./scrapers); what happens after the crawler hands back URLs
+- [Cache](./cache); crawler requests go through the rate limiter but not the cache

--- a/docs/usage/mediawiki.md
+++ b/docs/usage/mediawiki.md
@@ -13,9 +13,9 @@ Problem being solved: Different wikis have different structures. Some have a fla
 
 Decision tree: The `ScrapeOrchestrator` picks the mode based on what's present in your config or CLI:
 
-1. **`--category` CLI flag** — scrape one named category (overrides config).
-2. **`categories[]` in config** — iterate each category, deduplicate page titles across all categories, scrape the union.
-3. **Neither** — enumerate every article in main namespace via `fetchAllPages()`.
+1. **`--category` CLI flag**: scrape one named category (overrides config).
+2. **`categories[]` in config**: iterate each category, deduplicate page titles across all categories, scrape the union.
+3. **Neither**: enumerate every article in main namespace via `fetchAllPages()`.
 
 This ordering means: a CLI flag overrides config (don't allow config to force a full-wiki scrape if you wanted a single category). If config has `categories`, use them (don't hit the full wiki). Otherwise, fall back to full wiki.
 
@@ -52,7 +52,7 @@ Pages are fetched in batches of up to `batchSize` (default 50, MediaWiki's maxim
 
 Batch partial-failure behavior: If a batch request includes 50 page titles and one of them is a redirect or missing, the API returns the other 49 pages successfully. There's no explicit "failed pages" list; pages that exist are returned, missing pages are silently omitted. Your parse task receives only the pages that the API returned. If you're expecting 50 pages and get 49, something was missing or a redirect resolved to a different page title.
 
-Redirect resolution: The API resolves redirects transparently. If page A is a redirect to page B, the API returns page B's content under the original page A title in the request. The scraper doesn't know a redirect happened; it just gets the content. This is why `maxPages` stops after this many distinct titles are scraped, not after this many API requests — 50 pages in one batch might resolve to 49 unique pages if one was a redirect.
+Redirect resolution: The API resolves redirects transparently. If page A is a redirect to page B, the API returns page B's content under the original page A title in the request. The scraper doesn't know a redirect happened; it just gets the content. This is why `maxPages` stops after this many distinct titles are scraped, not after this many API requests; 50 pages in one batch might resolve to 49 unique pages if one was a redirect.
 
 Rate limiting per batch: Even though one API call fetches 50 pages, the rate limiter counts it as one request. If `rateLimitMs: 500`, you issue batch requests 500ms apart. Filling 1000 pages in batches of 50 means 20 batch requests, each separated by 500ms, for a total of ~10 seconds (ignoring any retry delays).
 
@@ -72,10 +72,10 @@ interface ParsedPageInterface {
 Two typed accessor methods so you don't write null-checks at every call site:
 
 ```ts
-// infoboxField(key) — returns string | null
+// infoboxField(key); returns string | null
 const name = parser.infoboxField('name');
 
-// infoboxNumber(key) — parses and returns number | null
+// infoboxNumber(key); parses and returns number | null
 const level = parser.infoboxNumber('level');
 ```
 
@@ -90,7 +90,7 @@ const level = parseInt(page.infobox['level'] ?? '', 10) || null;
 const displayName = page.infobox['name'] ?? page.title;
 ```
 
-These live on `WikitextParser`. In a plugin, use `state.input.parsedPage` directly — it's already been parsed before your task runs.
+These live on `WikitextParser`. In a plugin, use `state.input.parsedPage` directly; it's already been parsed before your task runs.
 
 ## Plugin pattern for MediaWiki
 
@@ -132,19 +132,19 @@ Cap the number of pages processed:
 "maxPages": 100
 ```
 
-Applied after enumeration — the scraper stops processing after this many pages regardless of how many the category or `allpages` enumeration returns. Useful for smoke tests against a full wiki without waiting for all 10,000 articles.
+Applied after enumeration; the scraper stops processing after this many pages regardless of how many the category or `allpages` enumeration returns. Useful for smoke tests against a full wiki without waiting for all 10,000 articles.
 
 ## Rate limiting and pagination
 
-`rateLimitMs` and `jitterMs` apply per API request (each batch counts as one request). For a large wiki, expect a long run at conservative rates. The cache is your friend — the first run is slow, subsequent runs skip the network entirely for cached pages.
+`rateLimitMs` and `jitterMs` apply per API request (each batch counts as one request). For a large wiki, expect a long run at conservative rates. The cache is your friend; the first run is slow, subsequent runs skip the network entirely for cached pages.
 
-Pagination stop condition: The `fetchAllPages()` method pages through the entire namespace using the MediaWiki `allpages` API. It stops when the API returns an empty batch (no more pages in the namespace). The batch is counted toward `maxPages` — if you set `maxPages: 100` and the API returns pages in batches of 50, you get one full batch (50 pages) and then the second batch stops because you've hit the limit. The orchestrator stops calling `fetchAllPages()` once enough pages have been fetched.
+Pagination stop condition: The `fetchAllPages()` method pages through the entire namespace using the MediaWiki `allpages` API. It stops when the API returns an empty batch (no more pages in the namespace). The batch is counted toward `maxPages`; if you set `maxPages: 100` and the API returns pages in batches of 50, you get one full batch (50 pages) and then the second batch stops because you've hit the limit. The orchestrator stops calling `fetchAllPages()` once enough pages have been fetched.
 
 `batchSize` worked example: If you set `batchSize: 50` and enumerate 1000 pages, that's 20 API requests, each with 50 page titles in the `titles` parameter. If you set `batchSize: 10`, that's 100 requests. Larger batches use less bandwidth and API calls but are riskier if a batch request times out (you lose more pages). The MediaWiki API caps individual requests at 50; Ripperoni respects that by clamping your config value.
 
 ## Related
 
-- [Scrapers](./scrapers) — HtmlScraper vs MediaWikiScraper comparison
-- [Configuration](./configuration) — full mediawiki config schema
-- [Cache](./cache) — caching wiki responses
-- [Plugins](./plugins) — full plugin authoring guide
+- [Scrapers](./scrapers); HtmlScraper vs MediaWikiScraper comparison
+- [Configuration](./configuration); full mediawiki config schema
+- [Cache](./cache); caching wiki responses
+- [Plugins](./plugins); full plugin authoring guide

--- a/docs/usage/mediawiki.md
+++ b/docs/usage/mediawiki.md
@@ -9,11 +9,15 @@ Ripperoni hits the MediaWiki JSON API directly. No mwn, no axios, no browser. Th
 
 ## Three enumeration modes
 
-The `ScrapeOrchestrator` picks the mode automatically:
+Problem being solved: Different wikis have different structures. Some have a flat list of all articles (enumerate via `allpages`). Some organize content in categories (enumerate via `categorymembers`). Some have both. The orchestrator needs to support all three modes without requiring you to rewrite your config each time.
 
-1. **`--category` flag** — scrape one named category.
-2. **`categories[]` in config** — iterate each category in the array, deduplicate page titles across them, scrape all.
+Decision tree: The `ScrapeOrchestrator` picks the mode based on what's present in your config or CLI:
+
+1. **`--category` CLI flag** — scrape one named category (overrides config).
+2. **`categories[]` in config** — iterate each category, deduplicate page titles across all categories, scrape the union.
 3. **Neither** — enumerate every article in main namespace via `fetchAllPages()`.
+
+This ordering means: a CLI flag overrides config (don't allow config to force a full-wiki scrape if you wanted a single category). If config has `categories`, use them (don't hit the full wiki). Otherwise, fall back to full wiki.
 
 ```json
 {
@@ -46,7 +50,11 @@ With `categories`:
 
 Pages are fetched in batches of up to `batchSize` (default 50, MediaWiki's maximum). The API returns wikitext for all pages in one request. Rate limiting applies once per batch, not once per page.
 
-Redirect resolution happens automatically — the API returns the redirect target, and the scraper follows it without a second request.
+Batch partial-failure behavior: If a batch request includes 50 page titles and one of them is a redirect or missing, the API returns the other 49 pages successfully. There's no explicit "failed pages" list; pages that exist are returned, missing pages are silently omitted. Your parse task receives only the pages that the API returned. If you're expecting 50 pages and get 49, something was missing or a redirect resolved to a different page title.
+
+Redirect resolution: The API resolves redirects transparently. If page A is a redirect to page B, the API returns page B's content under the original page A title in the request. The scraper doesn't know a redirect happened; it just gets the content. This is why `maxPages` stops after this many distinct titles are scraped, not after this many API requests — 50 pages in one batch might resolve to 49 unique pages if one was a redirect.
+
+Rate limiting per batch: Even though one API call fetches 50 pages, the rate limiter counts it as one request. If `rateLimitMs: 500`, you issue batch requests 500ms apart. Filling 1000 pages in batches of 50 means 20 batch requests, each separated by 500ms, for a total of ~10 seconds (ignoring any retry delays).
 
 ## WikitextParser
 
@@ -69,6 +77,17 @@ const name = parser.infoboxField('name');
 
 // infoboxNumber(key) — parses and returns number | null
 const level = parser.infoboxNumber('level');
+```
+
+Worked examples:
+
+```ts
+// infoboxField returns the value from the infobox, or null
+const name = page.infobox['name'];  // might be undefined; use ?? for default
+const level = parseInt(page.infobox['level'] ?? '', 10) || null;
+
+// Fallback to page title if no infobox name
+const displayName = page.infobox['name'] ?? page.title;
 ```
 
 These live on `WikitextParser`. In a plugin, use `state.input.parsedPage` directly — it's already been parsed before your task runs.
@@ -115,9 +134,13 @@ Cap the number of pages processed:
 
 Applied after enumeration — the scraper stops processing after this many pages regardless of how many the category or `allpages` enumeration returns. Useful for smoke tests against a full wiki without waiting for all 10,000 articles.
 
-## Rate limiting
+## Rate limiting and pagination
 
 `rateLimitMs` and `jitterMs` apply per API request (each batch counts as one request). For a large wiki, expect a long run at conservative rates. The cache is your friend — the first run is slow, subsequent runs skip the network entirely for cached pages.
+
+Pagination stop condition: The `fetchAllPages()` method pages through the entire namespace using the MediaWiki `allpages` API. It stops when the API returns an empty batch (no more pages in the namespace). The batch is counted toward `maxPages` — if you set `maxPages: 100` and the API returns pages in batches of 50, you get one full batch (50 pages) and then the second batch stops because you've hit the limit. The orchestrator stops calling `fetchAllPages()` once enough pages have been fetched.
+
+`batchSize` worked example: If you set `batchSize: 50` and enumerate 1000 pages, that's 20 API requests, each with 50 page titles in the `titles` parameter. If you set `batchSize: 10`, that's 100 requests. Larger batches use less bandwidth and API calls but are riskier if a batch request times out (you lose more pages). The MediaWiki API caps individual requests at 50; Ripperoni respects that by clamping your config value.
 
 ## Related
 

--- a/docs/usage/pipeline.md
+++ b/docs/usage/pipeline.md
@@ -7,11 +7,31 @@ title: Pipeline
 
 The pipeline is a typed async middleware queue. Tasks receive `(next, state)`. Call `next()` to hand off; skip it to terminate the chain early.
 
+Problem: Ripperoni needs to fetch a page, parse it with domain-specific logic (your plugin), and write it to disk — three separate concerns. The pipeline lets you plug in custom extraction logic (your parse task) without touching the HTTP or I/O machinery. Each task sees the state that previous tasks wrote and can add to it or skip execution.
+
+State machine: Each task either calls `await next()` to advance the queue or returns without calling it to terminate. There's no error handling middleware — if your parse task encounters invalid HTML, it just doesn't set `state.output` and skips `next()`. The write task sees `output === null` and decides (per config) whether to fail, warn, or skip the file. This gives you local control without exception bubbling.
+
 ```ts
 type TaskFnType<TState> = (next: () => Promise<void>, state: TState) => Promise<void>
 ```
 
 `TState` extends `Record<string, unknown>`. Tasks mutate state directly — the same reference flows through the whole chain.
+
+```mermaid
+flowchart TD
+    Start["pipeline.execute(state)"] -->|index=0| Task0["task 0"]
+    Task0 -->|calls next| Advance0["index += 1"]
+    Task0 -->|skips next| Done["Done: return state"]
+    Advance0 -->|index=1| Task1["task 1"]
+    Task1 -->|calls next| Advance1["index += 1"]
+    Task1 -->|skips next| Done
+    Advance1 -->|index=N+1| Task2["task N"]
+    Task2 -->|calls next| Advance2["index += 1"]
+    Advance2 -->|index > queue.length| Done
+    Task2 -->|skips next| Done
+```
+
+Why this matters: You can halt processing without throwing errors. If a task decides the data is too bad to parse, it returns without calling `next()`. The write task downstream sees the flag or missing field and handles it gracefully. No try/catch nesting, no promise rejection winding back up the stack.
 
 ## TaskRegistry
 
@@ -92,7 +112,7 @@ TaskRegistry.register('mysite:parse', async (next, state) => {
 
 No HTTP in the plugin. No file I/O in the plugin. The pipeline handles both. Your plugin just reads the HTML and writes a record.
 
-## Ordering
+## Ordering and early termination
 
 ```
 html:fetch  →  mysite:parse  →  json:write
@@ -100,7 +120,13 @@ html:fetch  →  mysite:parse  →  json:write
 
 `html:fetch` must come first. `json:write` must come last. Your parse task goes in between.
 
+Early termination: If `html:fetch` encounters a permanent HTTP error (e.g. 404) it throws, halting the pipeline. If your parse task finds malformed HTML it can skip `await next()` to prevent `json:write` from running. There's no explicit error handling middleware — control flow is implicit: a task either advances the queue or halts it.
+
+Unregistered task error: If your config names a pipeline task that doesn't exist (e.g. `["html:fetch", "nonexistent:parse", "json:write"]`), the error surfaces at orchestration time (when building the pipeline), not at runtime. The orchestrator calls `TaskRegistry.get()` which throws if the task is not registered. This means typos in your config fail fast before the scrape starts.
+
 For wiki targets, the orchestrator handles the fetch — your task receives a pre-populated `state.input` and sets `state.output`. The write task is always added last by the orchestrator.
+
+Task-name collision: If two tasks register the same name (e.g. two plugins both call `TaskRegistry.register('aonprd:parse', ...)`), the second registration overwrites the first. There's no warning or error. The last-loaded plugin wins. This is by design — your test plugins can shadow the production ones. If you're seeing the wrong task execute, check plugin load order in your config.
 
 ## ScrapeOrchestrator
 

--- a/docs/usage/pipeline.md
+++ b/docs/usage/pipeline.md
@@ -7,15 +7,15 @@ title: Pipeline
 
 The pipeline is a typed async middleware queue. Tasks receive `(next, state)`. Call `next()` to hand off; skip it to terminate the chain early.
 
-Problem: Ripperoni needs to fetch a page, parse it with domain-specific logic (your plugin), and write it to disk — three separate concerns. The pipeline lets you plug in custom extraction logic (your parse task) without touching the HTTP or I/O machinery. Each task sees the state that previous tasks wrote and can add to it or skip execution.
+Problem: Ripperoni needs to fetch a page, parse it with domain-specific logic (your plugin), and write it to disk; three separate concerns. The pipeline lets you plug in custom extraction logic (your parse task) without touching the HTTP or I/O machinery. Each task sees the state that previous tasks wrote and can add to it or skip execution.
 
-State machine: Each task either calls `await next()` to advance the queue or returns without calling it to terminate. There's no error handling middleware — if your parse task encounters invalid HTML, it just doesn't set `state.output` and skips `next()`. The write task sees `output === null` and decides (per config) whether to fail, warn, or skip the file. This gives you local control without exception bubbling.
+State machine: Each task either calls `await next()` to advance the queue or returns without calling it to terminate. There's no error handling middleware; if your parse task encounters invalid HTML, it just doesn't set `state.output` and skips `next()`. The write task sees `output === null` and decides (per config) whether to fail, warn, or skip the file. This gives you local control without exception bubbling.
 
 ```ts
 type TaskFnType<TState> = (next: () => Promise<void>, state: TState) => Promise<void>
 ```
 
-`TState` extends `Record<string, unknown>`. Tasks mutate state directly — the same reference flows through the whole chain.
+`TState` extends `Record<string, unknown>`. Tasks mutate state directly; the same reference flows through the whole chain.
 
 ```mermaid
 flowchart TD
@@ -70,11 +70,11 @@ interface PipelineStateInterface {
 }
 ```
 
-`state.input.html` — raw HTML string, set by `html:fetch`.
-`state.input.wikitext` — raw wikitext string, set by wiki fetch.
-`state.input.url` — the URL fetched.
+`state.input.html`; raw HTML string, set by `html:fetch`.
+`state.input.wikitext`; raw wikitext string, set by wiki fetch.
+`state.input.url`; the URL fetched.
 
-`state.output` — set by your parse task. `json:write` serializes this to disk.
+`state.output`; set by your parse task. `json:write` serializes this to disk.
 
 Tasks can attach extra keys using the `Record<string, unknown>` index signature. This is how tasks pass data to each other without coupling to canonical fields.
 
@@ -120,17 +120,17 @@ html:fetch  →  mysite:parse  →  json:write
 
 `html:fetch` must come first. `json:write` must come last. Your parse task goes in between.
 
-Early termination: If `html:fetch` encounters a permanent HTTP error (e.g. 404) it throws, halting the pipeline. If your parse task finds malformed HTML it can skip `await next()` to prevent `json:write` from running. There's no explicit error handling middleware — control flow is implicit: a task either advances the queue or halts it.
+Early termination: If `html:fetch` encounters a permanent HTTP error (e.g. 404) it throws, halting the pipeline. If your parse task finds malformed HTML it can skip `await next()` to prevent `json:write` from running. There's no explicit error handling middleware; control flow is implicit: a task either advances the queue or halts it.
 
 Unregistered task error: If your config names a pipeline task that doesn't exist (e.g. `["html:fetch", "nonexistent:parse", "json:write"]`), the error surfaces at orchestration time (when building the pipeline), not at runtime. The orchestrator calls `TaskRegistry.get()` which throws if the task is not registered. This means typos in your config fail fast before the scrape starts.
 
-For wiki targets, the orchestrator handles the fetch — your task receives a pre-populated `state.input` and sets `state.output`. The write task is always added last by the orchestrator.
+For wiki targets, the orchestrator handles the fetch; your task receives a pre-populated `state.input` and sets `state.output`. The write task is always added last by the orchestrator.
 
-Task-name collision: If two tasks register the same name (e.g. two plugins both call `TaskRegistry.register('aonprd:parse', ...)`), the second registration overwrites the first. There's no warning or error. The last-loaded plugin wins. This is by design — your test plugins can shadow the production ones. If you're seeing the wrong task execute, check plugin load order in your config.
+Task-name collision: If two tasks register the same name (e.g. two plugins both call `TaskRegistry.register('aonprd:parse', ...)`), the second registration overwrites the first. There's no warning or error. The last-loaded plugin wins. This is by design; your test plugins can shadow the production ones. If you're seeing the wrong task execute, check plugin load order in your config.
 
 ## ScrapeOrchestrator
 
-You don't build the pipeline directly — the `ScrapeOrchestrator` builds it per page from the target config. It:
+You don't build the pipeline directly; the `ScrapeOrchestrator` builds it per page from the target config. It:
 
 1. Resolves the target's `pipeline` array against the registry.
 2. Optionally prepends the fetch task.
@@ -170,7 +170,7 @@ state.output = {
 
 ## Related
 
-- [Configuration](./configuration) — pipeline declaration in config
-- [Scrapers](./scrapers) — what html:fetch hands your plugin
-- [MediaWiki](./mediawiki) — wiki-specific state shape
-- [Plugins](./plugins) — full plugin authoring guide
+- [Configuration](./configuration); pipeline declaration in config
+- [Scrapers](./scrapers); what html:fetch hands your plugin
+- [MediaWiki](./mediawiki); wiki-specific state shape
+- [Plugins](./plugins); full plugin authoring guide

--- a/docs/usage/plugins.md
+++ b/docs/usage/plugins.md
@@ -15,17 +15,37 @@ type TaskFnType<TState> = (next: () => Promise<void>, state: TState) => Promise<
 
 The task receives `next` (call it when you're done) and `state` (the pipeline state for the current page). Call `await next()` at the end.
 
-## What state provides
+Error handling: If your plugin throws an error, the error bubbles out of the pipeline and halts the orchestrator. There's no error recovery — the run fails. If you want to skip a malformed page gracefully, don't throw; instead, skip `await next()` or set a flag on state. The write task downstream can check the flag and decide whether to write.
+
+Plugin-load timing: Plugins are loaded by `TaskRegistry.load()` which imports the plugin file as an ES module. The module's top-level `TaskRegistry.register()` calls fire immediately. This happens before the orchestrator starts scraping, during the config parsing phase. If you have a syntax error in your plugin, you'll see it before any pages are scraped.
+
+## State shape per scraper
+
+For HTML targets, state.input is populated by `html:fetch`:
 
 ```ts
-state.targetId           // the target or mediawiki block name
+state.targetId           // the target block name (from config)
 state.source.url         // the URL being processed
-state.input.html         // raw HTML (set by html:fetch for HTML targets)
-state.input.wikitext     // raw wikitext (set by wiki fetch for mediawiki targets)
-state.input.parsedPage   // WikitextParser output (for mediawiki targets)
+state.input.html         // raw HTML string
 state.input.url          // the URL fetched
 state.output             // null until your plugin sets it; json:write reads this
 ```
+
+For MediaWiki targets, the orchestrator populates state.input before your plugin runs:
+
+```ts
+state.targetId           // the mediawiki block name (from config)
+state.source.url         // the canonical wiki page URL
+state.input.url          // the canonical wiki page URL
+state.input.title        // page title
+state.input.wikitext     // raw wikitext string
+state.input.parsedPage   // WikitextParser output (infobox, sections, categories)
+state.output             // null until your plugin sets it; json:write reads this
+```
+
+Inter-plugin state coordination: If you have multiple tasks in your pipeline (e.g. a pre-parse task that enriches state), they share the same state object. Task 1 can set arbitrary fields on state, and Task 2 sees them. This is how data flows between tasks without tight coupling. Tasks can attach extra keys using the `Record<string, unknown>` index signature.
+
+Plugin isolation: Plugins run serially within the pipeline for a single page, but the orchestrator runs multiple pages in parallel (via concurrency setting). Two pages never share state; they each get their own state object. Your plugin can't have global side effects that affect other pages (no shared counters, no global state mutations). If you need to coordinate across pages, use the file system or an external service.
 
 ## HTML plugin
 
@@ -117,7 +137,7 @@ _source: {
 
 ## Loading plugins
 
-Declare plugin paths in your config or load them programmatically:
+Plugins are declared in the target config under `plugins` (array of paths relative to the config file):
 
 ```json
 {
@@ -130,13 +150,15 @@ Declare plugin paths in your config or load them programmatically:
 }
 ```
 
-Or load manually:
+Plugins are loaded in array order. If two plugins register the same task name, the second one wins (overwrites the first). This allows test plugins to shadow production ones if you load them after.
+
+Or load manually in code:
 
 ```ts
 await TaskRegistry.load('./plugins/mysite.js');
 ```
 
-The module's top-level `TaskRegistry.register(...)` calls fire on import.
+The module's top-level `TaskRegistry.register(...)` calls fire on import. Plugin file paths are resolved relative to `process.cwd()`, not relative to the config file.
 
 ## Testing a plugin in isolation
 

--- a/docs/usage/plugins.md
+++ b/docs/usage/plugins.md
@@ -15,7 +15,7 @@ type TaskFnType<TState> = (next: () => Promise<void>, state: TState) => Promise<
 
 The task receives `next` (call it when you're done) and `state` (the pipeline state for the current page). Call `await next()` at the end.
 
-Error handling: If your plugin throws an error, the error bubbles out of the pipeline and halts the orchestrator. There's no error recovery — the run fails. If you want to skip a malformed page gracefully, don't throw; instead, skip `await next()` or set a flag on state. The write task downstream can check the flag and decide whether to write.
+Error handling: If your plugin throws an error, the error bubbles out of the pipeline and halts the orchestrator. There's no error recovery; the run fails. If you want to skip a malformed page gracefully, don't throw; instead, skip `await next()` or set a flag on state. The write task downstream can check the flag and decide whether to write.
 
 Plugin-load timing: Plugins are loaded by `TaskRegistry.load()` which imports the plugin file as an ES module. The module's top-level `TaskRegistry.register()` calls fire immediately. This happens before the orchestrator starts scraping, during the config parsing phase. If you have a syntax error in your plugin, you'll see it before any pages are scraped.
 
@@ -79,7 +79,7 @@ TaskRegistry.register('mysite:parse', async (next, state) => {
 });
 ```
 
-No HTTP in the plugin. No file I/O. No cheerio initialization — `html:fetch` has already fetched; you load the string into cheerio yourself. The pipeline handles the I/O, you handle the extraction.
+No HTTP in the plugin. No file I/O. No cheerio initialization; `html:fetch` has already fetched; you load the string into cheerio yourself. The pipeline handles the I/O, you handle the extraction.
 
 ## MediaWiki plugin
 
@@ -125,7 +125,7 @@ Every record should have `_type`. It's the field downstream tools (like Squashag
 
 ## The _source block
 
-Every record should have `_source`. Include at minimum `target`, `url`, and `plugin`. Squashage reads `_source.url` to derive graph IRIs — if it's missing, IRI derivation falls back to a default.
+Every record should have `_source`. Include at minimum `target`, `url`, and `plugin`. Squashage reads `_source.url` to derive graph IRIs; if it's missing, IRI derivation falls back to a default.
 
 ```ts
 _source: {
@@ -185,7 +185,7 @@ No HTTP, no file system, no network. Just the extraction logic.
 
 ## Related
 
-- [Pipeline](./pipeline) — how the task queue works
-- [Scrapers](./scrapers) — what state.input looks like per scraper type
-- [MediaWiki](./mediawiki) — infobox helpers and wiki-specific state
-- [Configuration](./configuration) — how to declare plugins in config
+- [Pipeline](./pipeline); how the task queue works
+- [Scrapers](./scrapers); what state.input looks like per scraper type
+- [MediaWiki](./mediawiki); infobox helpers and wiki-specific state
+- [Configuration](./configuration); how to declare plugins in config

--- a/docs/usage/scrapers.md
+++ b/docs/usage/scrapers.md
@@ -11,6 +11,8 @@ Two scraper classes. One for HTML, one for MediaWiki. Neither knows about the pi
 
 Native `fetch` + cheerio. No JSDOM. No headless browser. No JavaScript execution.
 
+Fetch state machine: When you call `HtmlScraper.fetch(url)`, this sequence runs: (1) rate limiter delays if needed, (2) cache is checked — if hit, return immediately (skip steps 3–5); (3) HTTP GET is issued with configured headers and timeout; (4) on error, ErrorClassifier decides if it's retryable — if yes, RetryExecutor waits and retries; if no, error is thrown; (5) on success (200), the response body is stored in cache and returned to the pipeline.
+
 What it does:
 1. Applies rate limiting and jitter from the target config.
 2. Checks the cache — returns the cached body on a hit.
@@ -40,17 +42,17 @@ For JS-rendered pages (single-page apps, lazy-loaded content): fetch via a headl
 
 Errors are classified into seven categories. Only four are retryable:
 
-| Category | Trigger | Retryable |
-|----------|---------|-----------|
-| `NETWORK` | `ECONNREFUSED`, `ECONNRESET`, `ENOTFOUND` | yes |
-| `TIMEOUT` | `ETIMEDOUT`, `ESOCKETTIMEDOUT` | yes |
-| `THROTTLED` | HTTP 429 (reads `Retry-After`) | yes |
-| `TRANSIENT` | HTTP 5xx | yes |
-| `PERMANENT` | HTTP 4xx (except 429) | no |
-| `VALIDATION` | `TypeError`, `SyntaxError` | no |
-| `RESOURCE` | `ENOMEM`, `ENOSPC` | no |
+| Category | Trigger | Retryable | Rationale |
+|----------|---------|-----------|-----------|
+| `NETWORK` | `ECONNREFUSED`, `ECONNRESET`, `ENOTFOUND` | yes | Network layer is transient; the server might be back up |
+| `TIMEOUT` | `ETIMEDOUT`, `ESOCKETTIMEDOUT` | yes | Timeout means the request got no response; server might recover |
+| `THROTTLED` | HTTP 429 (reads `Retry-After`) | yes | Server is asking you to wait and retry; honoring this prevents IP bans |
+| `TRANSIENT` | HTTP 5xx | yes | Server errors are temporary; the instance might recover or failover |
+| `PERMANENT` | HTTP 4xx (except 429) | no | 400, 403, 404, 410 mean the request is malformed or resource doesn't exist; retrying won't help |
+| `VALIDATION` | `TypeError`, `SyntaxError` | no | Your code (or the server's response parsing) is broken; retrying won't fix it |
+| `RESOURCE` | `ENOMEM`, `ENOSPC` | no | Your machine is out of memory or disk; retrying will just fail again |
 
-On `THROTTLED`: if the server sends a `Retry-After` header, that value overrides the configured backoff delay.
+On `THROTTLED`: if the server sends a `Retry-After` header, that value overrides the configured backoff delay. If the header is malformed (e.g. an unparseable date), the exponential backoff curve is used as a fallback.
 
 Retry config per target:
 
@@ -60,7 +62,7 @@ Retry config per target:
 "retryMaxDelayMs":  30000
 ```
 
-Delay formula: `min(baseDelay * 2^attempt, maxDelay) ± 10% jitter` to avoid thundering herd.
+Worst-case latency: With `maxRetries: 3, baseDelayMs: 500, multiplier: 2, maxDelayMs: 30000`, a single URL can take: initial attempt + 500ms + attempt + 1000ms + attempt + 2000ms + attempt = ~3.5 seconds in the best case (all retries fail). If the server throttles with a high `Retry-After`, you're waiting longer. Concurrency (from the target config) runs multiple URLs in parallel, so total time for N URLs is roughly `(N / concurrency) * maxLatency`.
 
 ---
 

--- a/docs/usage/scrapers.md
+++ b/docs/usage/scrapers.md
@@ -5,17 +5,17 @@ title: Scrapers
 
 # Scrapers
 
-Two scraper classes. One for HTML, one for MediaWiki. Neither knows about the pipeline. You don't use them directly — the orchestrator does — but knowing what they hand back tells you what your plugin receives.
+Two scraper classes. One for HTML, one for MediaWiki. Neither knows about the pipeline. You don't use them directly; the orchestrator does; but knowing what they hand back tells you what your plugin receives.
 
 ## HtmlScraper
 
 Native `fetch` + cheerio. No JSDOM. No headless browser. No JavaScript execution.
 
-Fetch state machine: When you call `HtmlScraper.fetch(url)`, this sequence runs: (1) rate limiter delays if needed, (2) cache is checked — if hit, return immediately (skip steps 3–5); (3) HTTP GET is issued with configured headers and timeout; (4) on error, ErrorClassifier decides if it's retryable — if yes, RetryExecutor waits and retries; if no, error is thrown; (5) on success (200), the response body is stored in cache and returned to the pipeline.
+Fetch state machine: When you call `HtmlScraper.fetch(url)`, this sequence runs: (1) rate limiter delays if needed, (2) cache is checked; if hit, return immediately (skip steps 3–5); (3) HTTP GET is issued with configured headers and timeout; (4) on error, ErrorClassifier decides if it's retryable; if yes, RetryExecutor waits and retries; if no, error is thrown; (5) on success (200), the response body is stored in cache and returned to the pipeline.
 
 What it does:
 1. Applies rate limiting and jitter from the target config.
-2. Checks the cache — returns the cached body on a hit.
+2. Checks the cache; returns the cached body on a hit.
 3. On a miss: sends the HTTP request. On error: retries with exponential backoff.
 4. On success: stores the body in cache, returns the page.
 
@@ -114,7 +114,7 @@ Use `MediaWikiScraper` (`mediawiki` block in config) when:
 
 ## Related
 
-- [Configuration](./configuration) — how to declare targets and mediawiki blocks
-- [MediaWiki](./mediawiki) — enumeration modes, infobox helpers
-- [Cache](./cache) — how caching integrates with both scrapers
-- [Pipeline](./pipeline) — what state.input looks like inside a parse task
+- [Configuration](./configuration); how to declare targets and mediawiki blocks
+- [MediaWiki](./mediawiki); enumeration modes, infobox helpers
+- [Cache](./cache); how caching integrates with both scrapers
+- [Pipeline](./pipeline); what state.input looks like inside a parse task

--- a/docs/walk-through.md
+++ b/docs/walk-through.md
@@ -1,10 +1,10 @@
 # Walk-through
 
-One concrete end-to-end example from URL to structured JSON record. The target is the [Archives of Nethys](https://2e.aonprd.com/) (aonprd) — the Pathfinder Second Edition rules reference. All of this is in `tests/e2e/fixtures/` and `plugins/aonprd/`.
+One concrete end-to-end example from URL to structured JSON record. The target is the [Archives of Nethys](https://2e.aonprd.com/) (aonprd): the Pathfinder Second Edition rules reference. All of this is in `tests/e2e/fixtures/` and `plugins/aonprd/`.
 
 ---
 
-## Before — the input
+## Before: the input
 
 Point Ripperoni at a detail page:
 
@@ -12,7 +12,7 @@ Point Ripperoni at a detail page:
 https://2e.aonprd.com/Feats.aspx?ID=750
 ```
 
-That URL resolves to the Power Attack feat page — a standard AON HTML page with a structured `<h1>`, a header field table, a body block, and inline links to other rules entries.
+That URL resolves to the Power Attack feat page: a standard AON HTML page with a structured `<h1>`, a header field table, a body block, and inline links to other rules entries.
 
 Ripperoni fetches the raw HTML, hands it to the configured plugin, and the plugin extracts a typed record. You never see raw HTML in your output.
 
@@ -54,7 +54,7 @@ Pipeline step breakdown:
 | Step | What it does |
 |------|-------------|
 | `html:fetch` | Rate-limited fetch with retry + backoff. Respects `Retry-After`. Reads from cache on hits. |
-| `aonprd:parse` | Plugin — loads the HTML into cheerio, extracts structured fields, writes `state.output`. |
+| `aonprd:parse` | Plugin: loads the HTML into cheerio, extracts structured fields, writes `state.output`. |
 | `json:write` | Writes `state.output` to `./output/aonprd/<slug>.json`. |
 
 ---
@@ -101,11 +101,11 @@ export function extractFeat($: CheerioAPI, url: string): FeatOutput {
 }
 ```
 
-This is the only domain-specific code. `getField`, `htmlToText`, and `harvestLinks` are shared helpers in `plugins/aonprd/common.ts`. `extractFeat` receives a `CheerioAPI` instance — no HTTP, no I/O, no side effects.
+This is the only domain-specific code. `getField`, `htmlToText`, and `harvestLinks` are shared helpers in `plugins/aonprd/common.ts`. `extractFeat` receives a `CheerioAPI` instance; no HTTP, no I/O, no side effects.
 
 ---
 
-## After — the JSON record
+## After: the JSON record
 
 ```json
 {
@@ -131,16 +131,16 @@ The `_source` block makes the record traceable back to its origin page. Downstre
 
 ## What ran in between
 
-1. **Rate-limited fetch** — waited `rateLimitMs` (1000ms) + up to `jitterMs` (250ms) random jitter before the request.
-2. **Cache check** — first run: cache miss, HTTP GET. Subsequent runs: cache hit, no network request.
-3. **Retry logic** — on transient failures (5xx, network timeout), retried up to `maxRetries` times with exponential backoff capped at `retryMaxDelayMs`.
-4. **Plugin executed** — `aonprd:parse` called with `(next, state)`. `state.input.html` contained the raw page HTML; the extractor ran cheerio selectors against it.
-5. **Record written** — `json:write` serialized `state.output` to `./output/aonprd/feats-750.json`.
+1. **Rate-limited fetch**: waited `rateLimitMs` (1000ms) + up to `jitterMs` (250ms) random jitter before the request.
+2. **Cache check**: first run: cache miss, HTTP GET. Subsequent runs: cache hit, no network request.
+3. **Retry logic**: on transient failures (5xx, network timeout), retried up to `maxRetries` times with exponential backoff capped at `retryMaxDelayMs`.
+4. **Plugin executed**: `aonprd:parse` called with `(next, state)`. `state.input.html` contained the raw page HTML; the extractor ran cheerio selectors against it.
+5. **Record written**: `json:write` serialized `state.output` to `./output/aonprd/feats-750.json`.
 
 ---
 
 ## Where to look next
 
-- [Architecture](./architecture) — pipeline phases, scraper contracts, extension points
-- [Getting started](./getting-started) — install, config, and first run
-- [Roadmap](./roadmap) — planned and shipped features
+- [Architecture](./architecture); pipeline phases, scraper contracts, extension points
+- [Getting started](./getting-started); install, config, and first run
+- [Roadmap](./roadmap); planned and shipped features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ripperoni",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ripperoni",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripperoni",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Web ingestion engine; slices wikis, sites, and URL lists into JSON records, one page at a time. Pairs with Squashage for RDF graph reconstitution.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ripperoni",
   "version": "2.3.0",
-  "description": "Web ingestion engine — slices wikis, sites, and URL lists into JSON records, one page at a time. Pairs with Squashage for RDF graph reconstitution.",
+  "description": "Web ingestion engine; slices wikis, sites, and URL lists into JSON records, one page at a time. Pairs with Squashage for RDF graph reconstitution.",
   "type": "module",
   "bin": {
     "ripperoni": "./dist/cli/cli.js"


### PR DESCRIPTION
## Summary
Minor release v2.4.0 — bundles mechanism-depth doc expansion (yamete-fidelity), em-dash cleanup (~95 occurrences), `actions/upload-artifact`/`upload-pages-artifact`/`deploy-pages`/`github-script` bumps (manually replayed from workflow-scope-blocked dependabot PRs).

## Type of Change
- [ ] Feature
- [ ] Breaking change
- [ ] Bug fix
- [x] Documentation
- [ ] Refactoring
- [x] Chore (release)

## Testing
- [x] CI matrix green
- [x] Lint, typecheck, unit tests pass
- [x] Em-dash audit verifies zero remaining in user-facing prose

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Documentation updated (CHANGELOG.md 2.4.0 entry)
- [x] All tests pass

## Related Issues
Bundles PR #43, #45 into v2.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
