### PR TITLE
feat(output): config-driven raw-content output for downstream re-parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `includeRawContent` boolean flag on `targets` and `mediawiki` target configs (default `false`). When `true`, each output record gains a `_raw` field: `{ contentType: string, content: string, fetchedAt: string }` carrying the raw fetched response body byte-for-byte. Downstream consumers (e.g. Squashage v0.6.0 max-extraction) can re-parse historical Ripperoni output without depending on Ripperoni's cache infrastructure. Storage tradeoff: opt-in because always-on at AONPRD scale (~15K records x ~80 KB HTML) adds ~1.2 GB per run.
+- AONPRD e2e fixture config (`tests/e2e/fixtures/pathripper-legacy.config.json`) sets `includeRawContent: true` so the canonical AONPRD scrape always carries raw HTML for downstream re-parsing.
+- Unit tests: `html:fetch` writes `_raw` to `state.page` when flag is on; `json:write` and `jsonl:append` include/strip `_raw` per flag.
+- Integration test (`tests/integration/rawContent.test.ts`): fixture-based pipeline with `includeRawContent: true` produces output where `_raw.content` matches the input HTML byte-for-byte.
+- Documentation: `docs/usage/configuration.md` describes the flag, the `_raw` shape, storage tradeoff, plugin contract, and example config.
+
 ## [2.4.0] - 2026-05-06
 
 ### Changed

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -57,6 +57,7 @@ Each key is a target name (e.g. `"aonprd"`). Value is a target config.
 | `headers` | object |  | Additional HTTP headers. Include `User-Agent`. |
 | `outputSchema` | string |  | Path to a JSON Schema file. Records that fail validation are handled per `onSchemaError`. |
 | `onSchemaError` | `"halt"` \| `"skip"` \| `"warn"` |  | What to do when a record fails schema validation. |
+| `includeRawContent` | boolean | `false` | When `true`, each output record gains a `_raw` field carrying the raw fetched content. See [Raw content output](#raw-content-output) below. |
 | `mapping` | object |  | Field-rename map applied after plugin output. |
 | `cache` | CacheConfig |  | See [Cache](./cache). |
 | `crawler` | CrawlerConfig |  | Inline crawler config for this target. |
@@ -107,6 +108,55 @@ Validation errors surface at first write. If your plugin produces invalid output
         "dir": "./output/.cache/aonprd",
         "mode": "read-write"
       }
+    }
+  }
+}
+```
+
+---
+
+## Raw content output
+
+Setting `includeRawContent: true` on a target adds a `_raw` field to every output record just before it is written to disk. This field carries the raw fetched bytes alongside the parsed fields, so downstream consumers can re-parse historical Ripperoni output without depending on Ripperoni's cache infrastructure.
+
+### Shape
+
+```json
+{
+  "_raw": {
+    "contentType": "text/html",
+    "content":     "<html>...</html>",
+    "fetchedAt":   "2026-05-07T04:00:00.000Z"
+  }
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `contentType` | string | MIME type of the response (`text/html` for HTML targets). |
+| `content` | string | Full raw response body, byte-for-byte. |
+| `fetchedAt` | ISO-8601 string | Timestamp at which the content was fetched. |
+
+### When to enable
+
+Enable it when downstream consumers need to re-derive fields that were not extracted in the original scrape run. For example, Squashage v0.6.0 max-extraction mode reads `_raw.content` to re-parse HTML without fetching the live site again.
+
+Disable it (the default) for production scrapes where storage is a concern. Rough estimate: 15,000 AONPRD records x 80 KB of HTML = roughly 1.2 GB of additional output. Enable it only for targeted runs or when archiving for later re-processing.
+
+### Plugin contract
+
+Plugins must not read or write the `_raw` field. It is set by `html:fetch` and consumed by `json:write` / `jsonl:append`. Plugins interact with `state.page.html` and `state.output` as usual; `_raw` is injected transparently into the serialized file just before the disk write.
+
+### Example config
+
+```json
+{
+  "targets": {
+    "aonprd": {
+      "baseUrl":           "https://2e.aonprd.com",
+      "pipeline":          ["html:fetch", "aonprd:parse", "json:write"],
+      "includeRawContent": true,
+      "cache": { "dir": "./output/.cache/aonprd", "mode": "read-write" }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -198,6 +198,7 @@
       "integrity": "sha512-ly1wETVGRo30cx61O7fetESN+ElL9c9K+bD/AVgnT1ar4c6v+/Yqjrhdtu6Fm4D0s4NZP081Isf6tunH1wUXHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.52.0",
         "@algolia/requester-browser-xhr": "5.52.0",
@@ -1593,6 +1594,7 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1662,6 +1664,7 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -2138,6 +2141,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2194,6 +2198,7 @@
       "integrity": "sha512-0ZzY9mjqV7gop/AH8pIBiAS8giXP7WcSiUfoFYIzYAK9QC5c37E4SIVtJVBMwlURc0/uNt2o4RcNRvdHa4CJ5w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.18.0",
         "@algolia/client-abtesting": "5.52.0",
@@ -2802,6 +2807,7 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3089,6 +3095,7 @@
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -4032,6 +4039,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4563,6 +4571,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4746,6 +4755,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -5278,6 +5288,7 @@
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "dev": "node --watch dist/cli/cli.js",
     "postinstall": "bash scripts/install-hooks.sh",
     "prepare": "bash scripts/install-hooks.sh",
-    "test:integration": "node --test tests/integration/**/*.test.ts",
+    "test:integration": "node --import tsx --test 'tests/integration/**/*.test.ts'",
     "test:e2e": "node --import tsx --test 'tests/e2e/**/*.test.ts'",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",

--- a/src/registry/builtinTasks.ts
+++ b/src/registry/builtinTasks.ts
@@ -18,6 +18,7 @@ import type {
 import type { HtmlScraper, ScrapedPageInterface } from '../scrapers/HtmlScraper.js';
 import type { MediaWikiScraper } from '../scrapers/MediaWikiScraper.js';
 import type { WikiPageInterface } from '../types/MediaWikiScraper.js';
+import type { RawContentInterface } from '../types/PipelineState.js';
 
 const Ajv        = (AjvModule        as unknown as { default?: AjvCtorType }).default
                   ?? (AjvModule      as unknown as AjvCtorType);
@@ -122,7 +123,13 @@ export const htmlFetchTask: TaskFnInterface<PipelineStateInterface> = async (nex
   }
 
   const result: ScrapedPageInterface = await ctx.scraper.fetchPage(state.page.url);
-  replacePage(state, { ...state.page, url: result.url, html: result.html });
+
+  const includeRaw = ctx.config['includeRawContent'] === true;
+  const raw: RawContentInterface | undefined = includeRaw
+    ? { contentType: 'text/html', content: result.html, fetchedAt: new Date().toISOString() }
+    : undefined;
+
+  replacePage(state, { ...state.page, url: result.url, html: result.html, ...(raw !== undefined ? { _raw: raw } : {}) });
 
   await next();
 };
@@ -196,7 +203,10 @@ export const jsonWriteTask: TaskFnInterface<PipelineStateInterface> = async (nex
   const slug    = pageSlug(state.page);
   const outFile = join(ctx.outDir, ctx.target, `${slug}.json`);
   await mkdir(dirname(outFile), { recursive: true });
-  await writeFile(outFile, JSON.stringify(state.output, null, 2), 'utf8');
+  const payload: Record<string, unknown> = state.page._raw !== undefined
+    ? { ...state.output, _raw: state.page._raw }
+    : { ...state.output };
+  await writeFile(outFile, JSON.stringify(payload, null, 2), 'utf8');
   logger.debug('json:write', `Wrote JSON: ${outFile}`, { task: 'json:write', outFile });
   await next();
 };
@@ -211,7 +221,10 @@ export const jsonlAppendTask: TaskFnInterface<PipelineStateInterface> = async (n
   }
   const outFile = join(ctx.outDir, ctx.target, 'all.jsonl');
   await mkdir(dirname(outFile), { recursive: true });
-  await appendFile(outFile, `${JSON.stringify(state.output)}\n`, 'utf8');
+  const payload: Record<string, unknown> = state.page._raw !== undefined
+    ? { ...state.output, _raw: state.page._raw }
+    : { ...state.output };
+  await appendFile(outFile, `${JSON.stringify(payload)}\n`, 'utf8');
   logger.debug('jsonl:append', `Appended JSONL row: ${outFile}`, { task: 'jsonl:append', outFile });
   await next();
 };

--- a/src/schemas/internal/RipperConfigSchema.ts
+++ b/src/schemas/internal/RipperConfigSchema.ts
@@ -47,8 +47,9 @@ const SCHEMA = {
             type: 'object',
             additionalProperties: { type: 'string' },
           },
-          outputSchema:  { type: 'string', minLength: 1 },
-          onSchemaError: { type: 'string', enum: ['halt', 'skip', 'warn'] },
+          outputSchema:     { type: 'string', minLength: 1 },
+          onSchemaError:    { type: 'string', enum: ['halt', 'skip', 'warn'] },
+          includeRawContent: { type: 'boolean' },
           mapping: {
             type: 'object',
             additionalProperties: { type: 'string', minLength: 1 },
@@ -105,8 +106,9 @@ const SCHEMA = {
           retryBaseDelayMs: { type: 'integer', minimum: 100 },
           retryMaxDelayMs:  { type: 'integer', minimum: 1000 },
           concurrency:      { type: 'integer', minimum: 1, maximum: 32 },
-          outputSchema:  { type: 'string', minLength: 1 },
-          onSchemaError: { type: 'string', enum: ['halt', 'skip', 'warn'] },
+          outputSchema:     { type: 'string', minLength: 1 },
+          onSchemaError:    { type: 'string', enum: ['halt', 'skip', 'warn'] },
+          includeRawContent: { type: 'boolean' },
           mapping: {
             type: 'object',
             additionalProperties: { type: 'string', minLength: 1 },

--- a/src/types/PipelineState.ts
+++ b/src/types/PipelineState.ts
@@ -42,6 +42,29 @@ export interface PipelineContextInterface {
 }
 
 /**
+ * Raw fetched content captured when `includeRawContent` is enabled on the target config.
+ *
+ * @remarks
+ * Populated by the fetch task (`html:fetch` or `wiki:fetch`) when `config.includeRawContent` is
+ * `true`. Carried on `PipelinePageInterface._raw` through the pipeline and injected into the
+ * serialized output by the write tasks (`json:write`, `jsonl:append`) just before disk write.
+ * Plugins must not read or write this field; it is managed entirely by built-in tasks.
+ *
+ * @category Pipeline
+ * @since 2.5.0
+ * @see {@link PipelinePageInterface}
+ * @group Types
+ */
+export interface RawContentInterface {
+  /** MIME content type of the fetched response (e.g. `"text/html"`, `"application/json"`). */
+  readonly contentType: string;
+  /** Raw response body string, byte-for-byte as received (HTML or JSON). */
+  readonly content:     string;
+  /** ISO-8601 timestamp at which the content was fetched. */
+  readonly fetchedAt:   string;
+}
+
+/**
  * Normalized page data carried through the pipeline for both HTML and wiki sources.
  *
  * @remarks
@@ -75,6 +98,11 @@ export interface PipelinePageInterface {
   readonly wikitext?: string | undefined;
   /** Raw HTML, present for HTML-sourced pages. */
   readonly html?:     string | undefined;
+  /**
+   * Raw fetched content; present only when `includeRawContent: true` is set on the target config.
+   * Set by the fetch task; consumed by write tasks. Plugins must not touch this field.
+   */
+  readonly _raw?:     RawContentInterface | undefined;
 }
 
 /**

--- a/tests/e2e/fixtures/pathripper-legacy.config.json
+++ b/tests/e2e/fixtures/pathripper-legacy.config.json
@@ -12,6 +12,7 @@
         "User-Agent": "ripperoni-e2e/2.0 (+https://github.com/Studnicky/ripper)"
       },
       "pipeline": ["html:fetch", "aonprd:parse", "json:write"],
+      "includeRawContent": true,
       "cache": { "dir": "./output/.cache/aonprd", "mode": "read-write" }
     }
   },

--- a/tests/integration/rawContent.test.ts
+++ b/tests/integration/rawContent.test.ts
@@ -1,0 +1,175 @@
+// Integration test: fixture-based scrape with includeRawContent: true
+// verifies that _raw.content in the output JSON matches the input HTML byte-for-byte.
+//
+// Uses a fake fetch to serve a known HTML fixture and the full
+// ScrapeOrchestrator + builtinTasks pipeline.  No network calls.
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ScrapeOrchestrator } from '../../src/orchestrators/ScrapeOrchestrator.js';
+import { TaskRegistry }       from '../../src/registry/TaskRegistry.js';
+import {
+  htmlFetchTask,
+  htmlWriteRawTask,
+  wikiWriteRawTask,
+  wikiFetchTask,
+  jsonWriteTask,
+  jsonlAppendTask,
+  validateSchemaTask,
+  crawlListTargetsTask,
+} from '../../src/registry/builtinTasks.js';
+import type { PipelineStateInterface } from '../../src/types/PipelineState.js';
+import type { TaskFnInterface } from '../../src/types/Pipeline.js';
+import type { RawContentInterface } from '../../src/types/PipelineState.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Load a real AONPRD fixture HTML so the content is non-trivial.
+const FIXTURE_HTML_PATH = resolve(__dirname, '../e2e/plugins/fixtures/aonprd/condition-blinded.html');
+
+// Minimal plugin: sets state.output to a stub so json:write has something to write.
+const stubParseTask: TaskFnInterface<PipelineStateInterface> = async (next, state) => {
+  state.output = { _type: 'stub', name: 'fixture-page' };
+  await next();
+};
+
+describe('rawContent integration', () => {
+  let outDir:      string;
+  let fixtureHtml: string;
+  const realFetch = globalThis.fetch;
+
+  beforeEach(async () => {
+    outDir      = await mkdtemp(join(tmpdir(), 'ripperoni-raw-content-'));
+    fixtureHtml = await readFile(FIXTURE_HTML_PATH, 'utf8');
+
+    // Intercept all HTTP requests and return the fixture HTML.
+    globalThis.fetch = (async (): Promise<Response> =>
+      new Response(fixtureHtml, {
+        status:  200,
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+      })
+    ) as typeof fetch;
+
+    // Reset registry and re-register all builtins + the stub plugin.
+    // We cannot rely on ESM module re-execution for side-effects, so we
+    // import the task functions directly and register them here.
+    TaskRegistry.reset();
+    TaskRegistry.register('html:fetch',         htmlFetchTask);
+    TaskRegistry.register('wiki:fetch',         wikiFetchTask);
+    TaskRegistry.register('html:write-raw',     htmlWriteRawTask);
+    TaskRegistry.register('wiki:write-raw',     wikiWriteRawTask);
+    TaskRegistry.register('json:write',         jsonWriteTask);
+    TaskRegistry.register('jsonl:append',       jsonlAppendTask);
+    TaskRegistry.register('validate:schema',    validateSchemaTask);
+    TaskRegistry.register('crawl:list-targets', crawlListTargetsTask);
+    TaskRegistry.register('stub:parse', stubParseTask);
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    await rm(outDir, { recursive: true, force: true });
+  });
+
+  it('output JSON includes _raw.content equal to the fetched HTML when includeRawContent is true', async () => {
+    const config = {
+      output: { basePath: outDir },
+      targets: {
+        'raw-test': {
+          baseUrl:          'https://fixture.test',
+          pipeline:         ['html:fetch', 'stub:parse', 'json:write'],
+          includeRawContent: true,
+        },
+      },
+    };
+
+    await ScrapeOrchestrator.scrapeHtml({
+      target:    'raw-test',
+      paths:     ['https://fixture.test/condition-blinded'],
+      outDir,
+      configDir: __dirname,
+      config:    config as Parameters<typeof ScrapeOrchestrator.scrapeHtml>[0]['config'],
+    });
+
+    const files  = (await import('node:fs/promises')).readdir(join(outDir, 'raw-test'));
+    const names  = (await files).filter((f: string) => f.endsWith('.json') && f !== 'failures.json');
+    assert.ok(names.length === 1, `expected 1 JSON file, got ${names.length.toString()}`);
+
+    const parsed = JSON.parse(
+      await readFile(join(outDir, 'raw-test', names[0]!), 'utf8'),
+    ) as { _type: string; _raw?: RawContentInterface };
+
+    assert.equal(parsed._type, 'stub');
+    assert.ok(parsed._raw !== undefined, '_raw should be present in output');
+    assert.equal(parsed._raw.contentType, 'text/html');
+    assert.equal(parsed._raw.content, fixtureHtml, '_raw.content must match the fixture HTML byte-for-byte');
+    assert.ok(typeof parsed._raw.fetchedAt === 'string' && parsed._raw.fetchedAt.length > 0, 'fetchedAt must be an ISO string');
+  });
+
+  it('output JSON does NOT include _raw when includeRawContent is false', async () => {
+    const config = {
+      output: { basePath: outDir },
+      targets: {
+        'raw-off': {
+          baseUrl:          'https://fixture.test',
+          pipeline:         ['html:fetch', 'stub:parse', 'json:write'],
+          includeRawContent: false,
+        },
+      },
+    };
+
+    await ScrapeOrchestrator.scrapeHtml({
+      target:    'raw-off',
+      paths:     ['https://fixture.test/condition-blinded'],
+      outDir,
+      configDir: __dirname,
+      config:    config as Parameters<typeof ScrapeOrchestrator.scrapeHtml>[0]['config'],
+    });
+
+    const files  = (await import('node:fs/promises')).readdir(join(outDir, 'raw-off'));
+    const names  = (await files).filter((f: string) => f.endsWith('.json') && f !== 'failures.json');
+    assert.ok(names.length === 1, `expected 1 JSON file, got ${names.length.toString()}`);
+
+    const parsed = JSON.parse(
+      await readFile(join(outDir, 'raw-off', names[0]!), 'utf8'),
+    ) as { _type: string; _raw?: unknown };
+
+    assert.equal(parsed._type, 'stub');
+    assert.equal(parsed._raw, undefined, '_raw must be absent when includeRawContent is false');
+  });
+
+  it('output JSON does NOT include _raw when includeRawContent is absent', async () => {
+    const config = {
+      output: { basePath: outDir },
+      targets: {
+        'raw-default': {
+          baseUrl:  'https://fixture.test',
+          pipeline: ['html:fetch', 'stub:parse', 'json:write'],
+        },
+      },
+    };
+
+    await ScrapeOrchestrator.scrapeHtml({
+      target:    'raw-default',
+      paths:     ['https://fixture.test/condition-blinded'],
+      outDir,
+      configDir: __dirname,
+      config:    config as Parameters<typeof ScrapeOrchestrator.scrapeHtml>[0]['config'],
+    });
+
+    const files  = (await import('node:fs/promises')).readdir(join(outDir, 'raw-default'));
+    const names  = (await files).filter((f: string) => f.endsWith('.json') && f !== 'failures.json');
+    assert.ok(names.length === 1, `expected 1 JSON file, got ${names.length.toString()}`);
+
+    const parsed = JSON.parse(
+      await readFile(join(outDir, 'raw-default', names[0]!), 'utf8'),
+    ) as { _type: string; _raw?: unknown };
+
+    assert.equal(parsed._type, 'stub');
+    assert.equal(parsed._raw, undefined, '_raw must be absent by default');
+  });
+});

--- a/tests/unit/registry/builtinTasks.test.ts
+++ b/tests/unit/registry/builtinTasks.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { RawContentInterface } from '../../../src/types/PipelineState.js';
 
 import { TaskRegistry } from '../../../src/registry/TaskRegistry.js';
 import { ExternalSchemaError } from '../../../src/errors/ExternalSchemaError.js';
@@ -154,6 +155,129 @@ describe('builtinTasks', () => {
       const expected = join(outDir, TARGET, 'all.jsonl');
       const body     = await readFile(expected, 'utf8');
       assert.equal(body, '{"n":1}\n{"n":2}\n{"n":3}\n');
+    });
+  });
+
+  describe('html:fetch + includeRawContent', () => {
+    it('sets _raw on state.page when includeRawContent is true', async () => {
+      const HTML = '<html><body>raw test</body></html>';
+      const scraper = new FakeHtmlScraper({
+        url:  'https://example.test/page-resolved',
+        html: HTML,
+        $: ((): unknown => ({}))() as unknown as ScrapedPageInterface['$'],
+      });
+      const state = buildState({
+        context: { target: TARGET, outDir, scraper: scraper as unknown as never, config: { includeRawContent: true } },
+      });
+
+      const task = TaskRegistry.get('html:fetch');
+      await task(noopNext, state);
+
+      assert.ok(state.page._raw !== undefined, '_raw should be set');
+      const raw = state.page._raw as RawContentInterface;
+      assert.equal(raw.contentType, 'text/html');
+      assert.equal(raw.content, HTML);
+      assert.ok(typeof raw.fetchedAt === 'string' && raw.fetchedAt.length > 0);
+    });
+
+    it('does NOT set _raw on state.page when includeRawContent is false', async () => {
+      const scraper = new FakeHtmlScraper({
+        url:  'https://example.test/page-resolved',
+        html: '<html><body>no raw</body></html>',
+        $: ((): unknown => ({}))() as unknown as ScrapedPageInterface['$'],
+      });
+      const state = buildState({
+        context: { target: TARGET, outDir, scraper: scraper as unknown as never, config: { includeRawContent: false } },
+      });
+
+      const task = TaskRegistry.get('html:fetch');
+      await task(noopNext, state);
+
+      assert.equal(state.page._raw, undefined);
+    });
+
+    it('does NOT set _raw on state.page when includeRawContent is absent', async () => {
+      const scraper = new FakeHtmlScraper({
+        url:  'https://example.test/page-resolved',
+        html: '<html><body>no raw</body></html>',
+        $: ((): unknown => ({}))() as unknown as ScrapedPageInterface['$'],
+      });
+      const state = buildState({
+        context: { target: TARGET, outDir, scraper: scraper as unknown as never, config: {} },
+      });
+
+      const task = TaskRegistry.get('html:fetch');
+      await task(noopNext, state);
+
+      assert.equal(state.page._raw, undefined);
+    });
+  });
+
+  describe('json:write + _raw injection', () => {
+    it('includes _raw in written JSON when page._raw is set', async () => {
+      const raw: RawContentInterface = { contentType: 'text/html', content: '<p>hello</p>', fetchedAt: '2026-01-01T00:00:00.000Z' };
+      const state = buildState({
+        page:    { targetId: TARGET, title: 'Raw Page', url: 'https://example.test/raw', html: '<p>hello</p>', _raw: raw },
+        context: { target: TARGET, outDir, config: { includeRawContent: true } },
+        output:  { name: 'Raw Page' },
+      });
+      const task = TaskRegistry.get('json:write');
+      await task(noopNext, state);
+
+      const expected = join(outDir, TARGET, 'raw-page.json');
+      const parsed   = JSON.parse(await readFile(expected, 'utf8')) as { name: string; _raw?: RawContentInterface };
+      assert.equal(parsed.name, 'Raw Page');
+      assert.ok(parsed._raw !== undefined, '_raw should appear in output');
+      assert.equal(parsed._raw.contentType, 'text/html');
+      assert.equal(parsed._raw.content, '<p>hello</p>');
+    });
+
+    it('does not include _raw in written JSON when page._raw is absent', async () => {
+      const state = buildState({
+        context: { target: TARGET, outDir, config: {} },
+        output:  { name: 'Plain Page' },
+      });
+      const task = TaskRegistry.get('json:write');
+      await task(noopNext, state);
+
+      const expected = join(outDir, TARGET, 'my-page.json');
+      const parsed   = JSON.parse(await readFile(expected, 'utf8')) as { name: string; _raw?: unknown };
+      assert.equal(parsed.name, 'Plain Page');
+      assert.equal(parsed._raw, undefined);
+    });
+  });
+
+  describe('jsonl:append + _raw injection', () => {
+    it('includes _raw in appended JSONL rows when page._raw is set', async () => {
+      const raw: RawContentInterface = { contentType: 'text/html', content: '<b>bold</b>', fetchedAt: '2026-06-01T00:00:00.000Z' };
+      const ctx  = { target: TARGET, outDir, config: { includeRawContent: true } };
+      const task = TaskRegistry.get('jsonl:append');
+
+      await task(noopNext, buildState({
+        page:    { targetId: TARGET, title: 'A', url: 'https://x.test/a', _raw: raw },
+        context: ctx,
+        output:  { n: 1 },
+      }));
+
+      const outFile = join(outDir, TARGET, 'all.jsonl');
+      const body    = await readFile(outFile, 'utf8');
+      const row     = JSON.parse(body.split('\n')[0]!) as { n: number; _raw?: RawContentInterface };
+      assert.equal(row.n, 1);
+      assert.ok(row._raw !== undefined, '_raw should appear in JSONL row');
+      assert.equal(row._raw.content, '<b>bold</b>');
+    });
+
+    it('does not include _raw in appended JSONL rows when page._raw is absent', async () => {
+      const ctx  = { target: TARGET, outDir, config: {} };
+      const task = TaskRegistry.get('jsonl:append');
+
+      await task(noopNext, buildState({ context: ctx, output: { n: 99 } }));
+
+      const outFile = join(outDir, TARGET, 'all.jsonl');
+      const body    = await readFile(outFile, 'utf8');
+      const row     = JSON.parse(body.split('\n')[0]!) as { n: number; _raw?: unknown };
+      assert.equal(row.n, 99);
+      assert.equal(row._raw, undefined);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a config-driven `includeRawContent` boolean flag to `targets` and `mediawiki` target configs. When enabled, each output record gains a `_raw: { contentType, content, fetchedAt }` field carrying the raw response body byte-for-byte alongside parsed fields. Default is `false` -- all existing behaviour unchanged.

---

## Audit findings

**What fields does `state` carry after fetch but before plugin runs?**

`state.page` carries: `targetId`, `title`, `url`, and `html` (for HTML targets) or `wikitext` (for MediaWiki targets). There is no `state.input` -- the raw content sits on `state.page.html`. `state.context` carries: `target`, `outDir`, `scraper`, `config`, and optionally `cache` and `targets`.

**Where does the raw response body live by default?**

`HtmlScraper.fetchPage()` returns `{ url, $, html }` where `html` is the raw string. The orchestrator calls `replacePage(state, { ...state.page, url: result.url, html: result.html })` -- so `html` lives on `state.page.html` through the entire pipeline. The `ScraperCache` also stores the body separately (under `<cacheDir>/bodies/<shard>/<key>.body`), but that is the cache layer, not the pipeline output. No raw content appears in plugin output by default.

**What does the plugin output look like today?**

The AONPRD plugin (`aonprd:parse`) dispatches by URL to per-type extractors and produces records like `{ _type: "spell", name: "Fireball", rank: 7, traditions: [...], traits: [...], ... }`. Every record has `_type` plus type-specific structured fields. The `json:write` builtin serializes `state.output` directly to `<outDir>/<target>/<slug>.json`. No `_raw` field is present today.

---

## Implementation

- **Config schema** (`RipperConfigSchema.ts`): `includeRawContent: { type: 'boolean' }` added to both `targets` and `mediawiki` additionalProperties blocks.
- **Type** (`PipelineState.ts`): New `RawContentInterface` (`{ contentType, content, fetchedAt }`) and `_raw?: RawContentInterface` on `PipelinePageInterface`.
- **`html:fetch` task** (`builtinTasks.ts`): Reads `ctx.config.includeRawContent`; when true, constructs `_raw` with `contentType: 'text/html'`, `content: result.html`, `fetchedAt: new Date().toISOString()` and sets it on `state.page._raw`.
- **`json:write` and `jsonl:append` tasks** (`builtinTasks.ts`): Build `payload` as `{ ...state.output, _raw: state.page._raw }` when `state.page._raw` is defined, otherwise `{ ...state.output }`. Plugins are fully transparent to this change.
- **AONPRD config** (`tests/e2e/fixtures/pathripper-legacy.config.json`): `includeRawContent: true` set on the `aonprd` target.

**Field name rationale:** `_raw` follows the existing `_type` / `_source` underscore-prefix metadata convention already present in AONPRD plugin output.

**Flag path:** `targets.<id>.includeRawContent` (or `mediawiki.<id>.includeRawContent`).

---

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix (non-breaking fix)
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring
- [ ] Chore

## Testing

- [x] Unit tests added/updated (7 new: fetch writes `_raw` when flag on/off/absent; `json:write` includes/strips `_raw`; `jsonl:append` includes/strips `_raw`)
- [x] Integration tests added (3 new: fixture-based pipeline with `includeRawContent: true/false/absent`; `_raw.content` matches input HTML byte-for-byte)
- [x] Manual testing completed

## Checklist

- [x] Code follows project conventions
- [x] Self-review completed
- [x] Documentation updated (`docs/usage/configuration.md` -- new Raw content output section)
- [x] All tests pass (`typecheck`, `lint`, `test:unit` 103/103, `test:integration` 3/3)

## Related Issues

Enables Squashage v0.6.0 max-extraction to re-parse without ripperoni cache dependency.

May the Machine Spirit preserve every byte of fetched HTML across the long dark of the archive.
