### PR TITLE
feat(output): split raw and plugin output into sibling folders

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -57,7 +57,7 @@ Each key is a target name (e.g. `"aonprd"`). Value is a target config.
 | `headers` | object |  | Additional HTTP headers. Include `User-Agent`. |
 | `outputSchema` | string |  | Path to a JSON Schema file. Records that fail validation are handled per `onSchemaError`. |
 | `onSchemaError` | `"halt"` \| `"skip"` \| `"warn"` |  | What to do when a record fails schema validation. |
-| `includeRawContent` | boolean | `true` | When `false`, the `_raw` field is stripped from output records. By default every record carries `_raw`. See [Raw content output](#raw-content-output) below. |
+| `includeRawContent` | boolean | `true` | When `false`, raw content is not populated on `state.page._raw` at all during the pipeline run. No raw file is written to `raw/`. See [Output folder layout](#output-folder-layout) below. |
 | `mapping` | object |  | Field-rename map applied after plugin output. |
 | `cache` | CacheConfig |  | See [Cache](./cache). |
 | `crawler` | CrawlerConfig |  | Inline crawler config for this target. |

--- a/src/orchestrators/ScrapeOrchestrator.ts
+++ b/src/orchestrators/ScrapeOrchestrator.ts
@@ -65,9 +65,13 @@ export class ScrapeOrchestrator {
 
     await import('../registry/builtinTasks.js');
 
-    const targetCfg     = htmlTarget as Record<string, unknown>;
-    const pipelineNames = ScrapeOrchestrator.requirePipeline(targetCfg, opts.target);
-    const pluginPaths   = ScrapeOrchestrator.derivePluginPaths(pipelineNames);
+    const targetCfg      = htmlTarget as Record<string, unknown>;
+    const pipelineNames  = ScrapeOrchestrator.requirePipeline(targetCfg, opts.target);
+    const pluginPaths    = ScrapeOrchestrator.derivePluginPaths(pipelineNames);
+    const pluginTaskName = ScrapeOrchestrator.derivePluginTaskName(pipelineNames);
+    const outputCfg      = opts.config.output as Record<string, unknown>;
+    const splitByTaskName: boolean | undefined =
+      typeof outputCfg['splitByTaskName'] === 'boolean' ? outputCfg['splitByTaskName'] as boolean : undefined;
     await TaskRegistry.loadAll(pluginPaths, opts.configDir);
 
     const cache       = ScrapeOrchestrator.buildCache(targetCfg);
@@ -106,6 +110,8 @@ export class ScrapeOrchestrator {
         scraper,
         config: targetCfg,
         ...(cache !== null ? { cache } : {}),
+        ...(pluginTaskName !== undefined ? { pluginTaskName } : {}),
+        ...(splitByTaskName !== undefined ? { splitByTaskName } : {}),
       };
       const pipeline = Pipeline.create<PipelineStateInterface>({ name: opts.target });
       for (const taskName of pipelineNames) {
@@ -149,9 +155,13 @@ export class ScrapeOrchestrator {
 
     await import('../registry/builtinTasks.js');
 
-    const targetCfg     = wikiTarget as Record<string, unknown>;
-    const pipelineNames = ScrapeOrchestrator.requirePipeline(targetCfg, opts.target);
-    const pluginPaths   = ScrapeOrchestrator.derivePluginPaths(pipelineNames);
+    const targetCfg      = wikiTarget as Record<string, unknown>;
+    const pipelineNames  = ScrapeOrchestrator.requirePipeline(targetCfg, opts.target);
+    const pluginPaths    = ScrapeOrchestrator.derivePluginPaths(pipelineNames);
+    const pluginTaskName = ScrapeOrchestrator.derivePluginTaskName(pipelineNames);
+    const outputCfgWiki  = opts.config.output as Record<string, unknown>;
+    const splitByTaskNameWiki: boolean | undefined =
+      typeof outputCfgWiki['splitByTaskName'] === 'boolean' ? outputCfgWiki['splitByTaskName'] as boolean : undefined;
     await TaskRegistry.loadAll(pluginPaths, opts.configDir);
 
     const cache       = ScrapeOrchestrator.buildCache(targetCfg);
@@ -211,6 +221,8 @@ export class ScrapeOrchestrator {
       resumeFailures: opts.resumeFailures === true,
       pipeline:       pipelineNames,
       targetConfig:   targetCfg,
+      ...(pluginTaskName !== undefined ? { pluginTaskName } : {}),
+      ...(splitByTaskNameWiki !== undefined ? { splitByTaskName: splitByTaskNameWiki } : {}),
     });
   }
 
@@ -226,6 +238,18 @@ export class ScrapeOrchestrator {
       }
     }
     return pipeline as string[];
+  }
+
+  /**
+   * Returns the name of the first non-built-in task in the pipeline, or `undefined`
+   * when no plugin step exists. Used to determine the plugin output subfolder.
+   */
+  private static derivePluginTaskName(pipeline: ReadonlyArray<string>): string | undefined {
+    for (const entry of pipeline) {
+      if (BUILTIN_PREFIXES.some((p: string): boolean => entry.startsWith(p))) continue;
+      return entry;
+    }
+    return undefined;
   }
 
   /**
@@ -326,7 +350,7 @@ export class ScrapeOrchestrator {
   }
 
   private static async runPipeline(opts: RunPipelineOptionsInterface): Promise<void> {
-    const { targetId, outDir, scraper, members, log, batchSize, concurrency, resumeFailures, pipeline: pipelineNames, targetConfig } = opts;
+    const { targetId, outDir, scraper, members, log, batchSize, concurrency, resumeFailures, pipeline: pipelineNames, targetConfig, pluginTaskName, splitByTaskName } = opts;
 
     // ── Resume: build set of already-written slugs ──────────────────────────
     const targetDir     = resolve(outDir, targetId);
@@ -376,6 +400,8 @@ export class ScrapeOrchestrator {
             outDir,
             scraper,
             config: targetConfig,
+            ...(pluginTaskName !== undefined ? { pluginTaskName } : {}),
+            ...(splitByTaskName !== undefined ? { splitByTaskName } : {}),
           },
         }),
       );

--- a/src/registry/builtinTasks.ts
+++ b/src/registry/builtinTasks.ts
@@ -42,14 +42,50 @@ const isWikiScraper = (s: unknown): s is MediaWikiScraper => {
 
 /** Lower-cases the input and replaces non `[a-z0-9-]` runs with single hyphens. */
 const toSlug = (raw: string): string => {
-  const lower    = raw.toLowerCase();
-  const replaced = lower.replace(/[^a-z0-9-]+/g, '-');
+  const lower     = raw.toLowerCase();
+  const replaced  = lower.replace(/[^a-z0-9-]+/g, '-');
   const collapsed = replaced.replace(/-+/g, '-');
   return collapsed.replace(/^-|-$/g, '');
 };
 
-/** Returns the slug for a page, preferring `title` and falling back to `url`. */
+/**
+ * Derives a safe filename stem from a URL.
+ *
+ * Takes the path and query string, replaces `?`, `=`, `&`, `/`, `#` and other
+ * non-safe characters with hyphens, collapses repeats, and trims edge hyphens.
+ *
+ * Example: `https://2e.aonprd.com/Feats.aspx?ID=750` -> `Feats.aspx-ID-750`
+ */
+const urlToFilename = (url: string): string => {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    // Treat as a plain string slug if not a valid absolute URL.
+    return toSlug(url);
+  }
+  // Combine pathname (strip leading slash) and search (strip leading ?)
+  const path   = parsed.pathname.replace(/^\//, '');
+  const search = parsed.search.replace(/^\?/, '');
+  const raw    = search.length > 0 ? `${path}?${search}` : path;
+  // Replace URL separators with hyphens, then collapse and trim.
+  const slug   = raw.replace(/[/?=&#]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+  return slug.length > 0 ? slug : toSlug(url);
+};
+
+/** Returns the slug for a page, preferring URL-based derivation for absolute URLs and falling back to title. */
 const pageSlug = (page: PipelinePageInterface): string => {
+  // Prefer URL-derived filename when the URL is a valid absolute URL.
+  if (page.url.length > 0) {
+    try {
+      new URL(page.url);
+      const slug = urlToFilename(page.url);
+      if (slug.length > 0) return slug;
+    } catch {
+      // Fall through to title-based slug.
+    }
+  }
+  // Fall back to title-based slug (used for wiki pages and URL-less pages).
   const source = page.title.length > 0 ? page.title : page.url;
   const slug   = toSlug(source);
   if (slug.length === 0) {
@@ -192,7 +228,16 @@ export const wikiWriteRawTask: TaskFnInterface<PipelineStateInterface> = async (
   await next();
 };
 
-/** Writes `state.output` (or `{}` if null) as 2-space JSON to `<outDir>/<target>/<slug>.json`; skips when output is null. */
+/**
+ * Writes `state.output` as 2-space JSON to `<outDir>/<target>/<pluginTaskName>/<slug>.json`.
+ *
+ * When `ctx.pluginTaskName` is set (a plugin step exists in the pipeline), the file is written
+ * under a subfolder named after the plugin task. When absent (raw-dump-only pipeline), the file
+ * is written directly under `<outDir>/<target>/`. The `_raw` field is NOT embedded; raw content
+ * lives in the sibling `raw/` folder written by `html:write-raw` or `wiki:write-raw`.
+ *
+ * Skips when `state.output` is null.
+ */
 export const jsonWriteTask: TaskFnInterface<PipelineStateInterface> = async (next, state) => {
   const ctx = requireContext(state, 'json:write');
   if (state.output === null) {
@@ -200,18 +245,29 @@ export const jsonWriteTask: TaskFnInterface<PipelineStateInterface> = async (nex
     await next();
     return;
   }
-  const slug    = pageSlug(state.page);
-  const outFile = join(ctx.outDir, ctx.target, `${slug}.json`);
+  const slug            = pageSlug(state.page);
+  const splitByTaskName = ctx.splitByTaskName !== false;
+  const subdir          = (ctx.pluginTaskName !== undefined && splitByTaskName) ? ctx.pluginTaskName : '';
+  const outFile         = subdir.length > 0
+    ? join(ctx.outDir, ctx.target, subdir, `${slug}.json`)
+    : join(ctx.outDir, ctx.target, `${slug}.json`);
   await mkdir(dirname(outFile), { recursive: true });
-  const payload: Record<string, unknown> = state.page._raw !== undefined
-    ? { ...state.output, _raw: state.page._raw }
-    : { ...state.output };
+  // _raw is NOT embedded here — it lives in the sibling raw/ folder.
+  const payload: Record<string, unknown> = { ...state.output };
   await writeFile(outFile, JSON.stringify(payload, null, 2), 'utf8');
   logger.debug('json:write', `Wrote JSON: ${outFile}`, { task: 'json:write', outFile });
   await next();
 };
 
-/** Appends `JSON.stringify(state.output) + '\n'` to `<outDir>/<target>/all.jsonl`. */
+/**
+ * Appends `JSON.stringify(state.output) + '\n'` to `<outDir>/<target>/<pluginTaskName>/all.jsonl`.
+ *
+ * When `ctx.pluginTaskName` is set, the file is appended under the plugin subfolder.
+ * When absent, appends to `<outDir>/<target>/all.jsonl`. The `_raw` field is NOT embedded;
+ * raw content lives in the sibling `raw/` folder.
+ *
+ * Skips when `state.output` is null.
+ */
 export const jsonlAppendTask: TaskFnInterface<PipelineStateInterface> = async (next, state) => {
   const ctx = requireContext(state, 'jsonl:append');
   if (state.output === null) {
@@ -219,11 +275,14 @@ export const jsonlAppendTask: TaskFnInterface<PipelineStateInterface> = async (n
     await next();
     return;
   }
-  const outFile = join(ctx.outDir, ctx.target, 'all.jsonl');
+  const splitByTaskName = ctx.splitByTaskName !== false;
+  const subdir          = (ctx.pluginTaskName !== undefined && splitByTaskName) ? ctx.pluginTaskName : '';
+  const outFile         = subdir.length > 0
+    ? join(ctx.outDir, ctx.target, subdir, 'all.jsonl')
+    : join(ctx.outDir, ctx.target, 'all.jsonl');
   await mkdir(dirname(outFile), { recursive: true });
-  const payload: Record<string, unknown> = state.page._raw !== undefined
-    ? { ...state.output, _raw: state.page._raw }
-    : { ...state.output };
+  // _raw is NOT embedded here — it lives in the sibling raw/ folder.
+  const payload: Record<string, unknown> = { ...state.output };
   await appendFile(outFile, `${JSON.stringify(payload)}\n`, 'utf8');
   logger.debug('jsonl:append', `Appended JSONL row: ${outFile}`, { task: 'jsonl:append', outFile });
   await next();

--- a/src/schemas/internal/RipperConfigSchema.ts
+++ b/src/schemas/internal/RipperConfigSchema.ts
@@ -23,9 +23,12 @@ const SCHEMA = {
       additionalProperties: false,
       required: ['basePath'],
       properties: {
-        basePath: { type: 'string', minLength: 1 },
-        format:   { type: 'string', enum: ['json', 'html', 'text'] },
-        pretty:   { type: 'boolean' },
+        basePath:         { type: 'string', minLength: 1 },
+        format:           { type: 'string', enum: ['json', 'html', 'text'] },
+        pretty:           { type: 'boolean' },
+        rawSubdir:        { type: 'string', minLength: 1 },
+        rawExt:           { type: 'string', minLength: 1 },
+        splitByTaskName:  { type: 'boolean' },
       },
     },
     targets: {

--- a/src/types/PipelineState.ts
+++ b/src/types/PipelineState.ts
@@ -28,15 +28,27 @@ import type { ScraperCache } from '../modules/cache/ScraperCache.js';
  */
 export interface PipelineContextInterface {
   /** Scrape target identifier from the config. */
-  readonly target:   string;
+  readonly target:          string;
   /** Output base directory; tasks write under `<outDir>/<target>/...`. */
-  readonly outDir:   string;
+  readonly outDir:          string;
   /** Scraper instance used by fetch tasks; absent when not required. */
-  readonly scraper?: HtmlScraper | MediaWikiScraper | undefined;
+  readonly scraper?:        HtmlScraper | MediaWikiScraper | undefined;
   /** Per-target configuration object as supplied by the loaded ripper config. */
-  readonly config:   Record<string, unknown>;
+  readonly config:          Record<string, unknown>;
   /** Optional shared content store; used by `crawl:list-targets` and any task that needs the same cache the scraper sees. */
-  readonly cache?:   ScraperCache | undefined;
+  readonly cache?:          ScraperCache | undefined;
+  /**
+   * Name of the first non-built-in pipeline task (the plugin step), if any.
+   * Used by write tasks to determine the plugin output subfolder.
+   * Absent when no plugin step is present in the pipeline.
+   */
+  readonly pluginTaskName?: string | undefined;
+  /**
+   * When `false`, plugin output is written to a single file (`<plugin-task-name>.jsonl`-style)
+   * rather than a subfolder per record. Mirrors `output.splitByTaskName` from the global config.
+   * Defaults to `true` when absent.
+   */
+  readonly splitByTaskName?: boolean | undefined;
   /** Discovered target URLs (populated by `crawl:list-targets`); orchestrator iterates this when set. */
   targets?: ReadonlyArray<string>;
 }

--- a/src/types/ScrapeOrchestrator.ts
+++ b/src/types/ScrapeOrchestrator.ts
@@ -29,9 +29,13 @@ export interface RunPipelineOptionsInterface {
   /** When true, delete failures.json after a successful retry run. */
   readonly resumeFailures: boolean;
   /** Pipeline task names to run for each fetched wiki page. */
-  readonly pipeline:       ReadonlyArray<string>;
+  readonly pipeline:        ReadonlyArray<string>;
   /** Per-target config object for state.context.config. */
-  readonly targetConfig:   Record<string, unknown>;
+  readonly targetConfig:    Record<string, unknown>;
+  /** Name of the first non-built-in task (plugin step); absent when no plugin exists. */
+  readonly pluginTaskName?:  string | undefined;
+  /** When false, write plugin output to a single JSONL rather than per-record files in a subfolder. */
+  readonly splitByTaskName?: boolean | undefined;
 }
 
 /**

--- a/tests/e2e/aonprd-plugin.test.ts
+++ b/tests/e2e/aonprd-plugin.test.ts
@@ -178,19 +178,23 @@ describe('PathRipper legacy AONPRD plugin e2e (local only)', () => {
         config:    fx,
       });
 
-      const targetDir = resolve(outDir, 'aonprd');
-      const files     = await readdir(targetDir);
+      // Plugin output now lives in <targetDir>/<pluginTaskName>/ subfolder.
+      // The pipeline task is 'aonprd:parse', so folder = <targetDir>/aonprd:parse/
+      const targetDir  = resolve(outDir, 'aonprd');
+      const pluginDir  = resolve(targetDir, 'aonprd:parse');
+      const files      = (await readdir(pluginDir)).filter((f: string) => f.endsWith('.json') && f !== 'failures.json');
       assert.ok(files.length === sample.length,
-        `expected ${sample.length.toString()} JSON files, got ${files.length.toString()}`);
+        `expected ${sample.length.toString()} JSON files in aonprd:parse/, got ${files.length.toString()}`);
       for (const f of files) {
-        const json = JSON.parse(await readFile(resolve(targetDir, f), 'utf-8')) as {
-          _type: string; name?: string; source?: { book: string | null };
+        const json = JSON.parse(await readFile(resolve(pluginDir, f), 'utf-8')) as {
+          _type: string; name?: string; source?: { book: string | null }; _raw?: unknown;
         };
         process.stdout.write(`    • ${f}  →  _type=${json._type}  name=${json.name ?? '?'}\n`);
         assert.ok(json._type !== undefined, `${f}: missing _type discriminator`);
         assert.ok(json.name !== undefined && json.name !== '', `${f}: missing name`);
         assert.ok(json.source !== undefined && json.source.book !== null,
           `${f}: missing source.book`);
+        assert.equal(json._raw, undefined, `${f}: _raw must NOT be embedded in plugin JSON`);
       }
     } finally {
       await rm(outDir, { recursive: true, force: true });

--- a/tests/e2e/aonprd-snapshot.test.ts
+++ b/tests/e2e/aonprd-snapshot.test.ts
@@ -116,18 +116,21 @@ describe('AONPRD snapshot e2e (local only)', () => {
       assert.equal(fetchCalls.length, 0,
         `phase 2 must not hit the network; saw: ${fetchCalls.join(', ')}`);
 
-      const phase2Files = (await readdir(targetDir)).filter((f: string): boolean =>
+      // Plugin output now lives in <targetDir>/aonprd:parse/ subfolder.
+      const pluginDir   = resolve(targetDir, 'aonprd:parse');
+      const phase2Files = (await readdir(pluginDir)).filter((f: string): boolean =>
         f.endsWith('.json') && f !== 'failures.json',
       );
       assert.ok(phase2Files.length === PROBES.length,
-        `phase 2: expected ${PROBES.length.toString()} JSON files, got ${phase2Files.length.toString()}`);
+        `phase 2: expected ${PROBES.length.toString()} JSON files in aonprd:parse/, got ${phase2Files.length.toString()}`);
       for (const f of phase2Files) {
-        const json = JSON.parse(await readFile(resolve(targetDir, f), 'utf-8')) as {
-          _type?: string; name?: string; source?: { book: string | null };
+        const json = JSON.parse(await readFile(resolve(pluginDir, f), 'utf-8')) as {
+          _type?: string; name?: string; source?: { book: string | null }; _raw?: unknown;
         };
         assert.ok(json._type !== undefined && json._type !== '', `${f}: missing _type`);
         assert.ok(json.name  !== undefined && json.name  !== '', `${f}: missing name`);
         assert.ok(json.source !== undefined && json.source.book !== null, `${f}: missing source.book`);
+        assert.equal(json._raw, undefined, `${f}: _raw must NOT be embedded in plugin JSON`);
       }
     } finally {
       await rm(outDir, { recursive: true, force: true });

--- a/tests/integration/rawContent.test.ts
+++ b/tests/integration/rawContent.test.ts
@@ -1,12 +1,14 @@
-// Integration test: fixture-based scrape with includeRawContent: true
-// verifies that _raw.content in the output JSON matches the input HTML byte-for-byte.
+// Integration test: fixture-based scrape with the new folder-split output layout.
+//
+// Raw content (html) goes to <outDir>/<target>/raw/<slug>.html
+// Plugin JSON goes to <outDir>/<target>/<pluginTaskName>/<slug>.json  (no _raw embed)
 //
 // Uses a fake fetch to serve a known HTML fixture and the full
 // ScrapeOrchestrator + builtinTasks pipeline.  No network calls.
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -25,7 +27,6 @@ import {
 } from '../../src/registry/builtinTasks.js';
 import type { PipelineStateInterface } from '../../src/types/PipelineState.js';
 import type { TaskFnInterface } from '../../src/types/Pipeline.js';
-import type { RawContentInterface } from '../../src/types/PipelineState.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -38,7 +39,7 @@ const stubParseTask: TaskFnInterface<PipelineStateInterface> = async (next, stat
   await next();
 };
 
-describe('rawContent integration', () => {
+describe('rawContent integration (folder-split layout)', () => {
   let outDir:      string;
   let fixtureHtml: string;
   const realFetch = globalThis.fetch;
@@ -56,8 +57,6 @@ describe('rawContent integration', () => {
     ) as typeof fetch;
 
     // Reset registry and re-register all builtins + the stub plugin.
-    // We cannot rely on ESM module re-execution for side-effects, so we
-    // import the task functions directly and register them here.
     TaskRegistry.reset();
     TaskRegistry.register('html:fetch',         htmlFetchTask);
     TaskRegistry.register('wiki:fetch',         wikiFetchTask);
@@ -75,7 +74,9 @@ describe('rawContent integration', () => {
     await rm(outDir, { recursive: true, force: true });
   });
 
-  it('output JSON includes _raw.content by default (no flag set)', async () => {
+  it('plugin pipeline writes JSON to <target>/<pluginTaskName>/ and does NOT embed _raw', async () => {
+    // Pipeline: html:fetch -> stub:parse -> json:write
+    // stub:parse is the pluginTaskName; orchestrator injects it into context.
     const config = {
       output: { basePath: outDir },
       targets: {
@@ -94,57 +95,86 @@ describe('rawContent integration', () => {
       config:    config as Parameters<typeof ScrapeOrchestrator.scrapeHtml>[0]['config'],
     });
 
-    const files  = (await import('node:fs/promises')).readdir(join(outDir, 'raw-default'));
-    const names  = (await files).filter((f: string) => f.endsWith('.json') && f !== 'failures.json');
-    assert.ok(names.length === 1, `expected 1 JSON file, got ${names.length.toString()}`);
+    // Plugin JSON should be in <target>/stub:parse/ subfolder
+    const pluginDir = join(outDir, 'raw-default', 'stub:parse');
+    const files     = (await readdir(pluginDir)).filter((f: string) => f.endsWith('.json') && f !== 'failures.json');
+    assert.ok(files.length === 1, `expected 1 plugin JSON file, got ${files.length.toString()}`);
 
     const parsed = JSON.parse(
-      await readFile(join(outDir, 'raw-default', names[0]!), 'utf8'),
-    ) as { _type: string; _raw?: RawContentInterface };
+      await readFile(join(pluginDir, files[0]!), 'utf8'),
+    ) as { _type: string; name: string; _raw?: unknown };
 
     assert.equal(parsed._type, 'stub');
-    assert.ok(parsed._raw !== undefined, '_raw should be present by default');
-    assert.equal(parsed._raw.contentType, 'text/html');
-    assert.equal(parsed._raw.content, fixtureHtml, '_raw.content must match the fixture HTML byte-for-byte');
-    assert.ok(typeof parsed._raw.fetchedAt === 'string' && parsed._raw.fetchedAt.length > 0, 'fetchedAt must be an ISO string');
+    assert.equal(parsed.name, 'fixture-page');
+    assert.equal(parsed._raw, undefined, '_raw must NOT be embedded in plugin JSON');
   });
 
-  it('output JSON includes _raw.content equal to the fetched HTML when includeRawContent is explicitly true', async () => {
+  it('raw HTML is written to <target>/raw/<slug>.html when html:write-raw is in pipeline', async () => {
     const config = {
       output: { basePath: outDir },
       targets: {
-        'raw-test': {
-          baseUrl:           'https://fixture.test',
-          pipeline:          ['html:fetch', 'stub:parse', 'json:write'],
-          includeRawContent: true,
+        'raw-html': {
+          baseUrl:  'https://fixture.test',
+          pipeline: ['html:fetch', 'html:write-raw', 'stub:parse', 'json:write'],
         },
       },
     };
 
     await ScrapeOrchestrator.scrapeHtml({
-      target:    'raw-test',
+      target:    'raw-html',
       paths:     ['https://fixture.test/condition-blinded'],
       outDir,
       configDir: __dirname,
       config:    config as Parameters<typeof ScrapeOrchestrator.scrapeHtml>[0]['config'],
     });
 
-    const files  = (await import('node:fs/promises')).readdir(join(outDir, 'raw-test'));
-    const names  = (await files).filter((f: string) => f.endsWith('.json') && f !== 'failures.json');
-    assert.ok(names.length === 1, `expected 1 JSON file, got ${names.length.toString()}`);
+    // Raw HTML should be in <target>/raw/ subfolder
+    const rawDir  = join(outDir, 'raw-html', 'raw');
+    const rawFiles = (await readdir(rawDir)).filter((f: string) => f.endsWith('.html'));
+    assert.ok(rawFiles.length === 1, `expected 1 raw HTML file, got ${rawFiles.length.toString()}`);
 
-    const parsed = JSON.parse(
-      await readFile(join(outDir, 'raw-test', names[0]!), 'utf8'),
-    ) as { _type: string; _raw?: RawContentInterface };
+    const rawContent = await readFile(join(rawDir, rawFiles[0]!), 'utf8');
+    assert.equal(rawContent, fixtureHtml, 'raw HTML must match fixture byte-for-byte');
 
-    assert.equal(parsed._type, 'stub');
-    assert.ok(parsed._raw !== undefined, '_raw should be present when explicitly opted in');
-    assert.equal(parsed._raw.contentType, 'text/html');
-    assert.equal(parsed._raw.content, fixtureHtml, '_raw.content must match the fixture HTML byte-for-byte');
-    assert.ok(typeof parsed._raw.fetchedAt === 'string' && parsed._raw.fetchedAt.length > 0, 'fetchedAt must be an ISO string');
+    // Plugin JSON in stub:parse subfolder
+    const pluginDir  = join(outDir, 'raw-html', 'stub:parse');
+    const jsonFiles  = (await readdir(pluginDir)).filter((f: string) => f.endsWith('.json'));
+    assert.ok(jsonFiles.length === 1, `expected 1 plugin JSON file in stub:parse/, got ${jsonFiles.length.toString()}`);
   });
 
-  it('output JSON does NOT include _raw when includeRawContent is false (opt-out)', async () => {
+  it('no-plugin pipeline (raw-only): only raw/ folder is populated, no plugin subfolder', async () => {
+    // Pipeline: html:fetch -> html:write-raw (no json:write or plugin)
+    const config = {
+      output: { basePath: outDir },
+      targets: {
+        'raw-only': {
+          baseUrl:  'https://fixture.test',
+          pipeline: ['html:fetch', 'html:write-raw'],
+        },
+      },
+    };
+
+    await ScrapeOrchestrator.scrapeHtml({
+      target:    'raw-only',
+      paths:     ['https://fixture.test/condition-blinded'],
+      outDir,
+      configDir: __dirname,
+      config:    config as Parameters<typeof ScrapeOrchestrator.scrapeHtml>[0]['config'],
+    });
+
+    // Raw HTML should exist
+    const rawDir   = join(outDir, 'raw-only', 'raw');
+    const rawFiles = (await readdir(rawDir)).filter((f: string) => f.endsWith('.html'));
+    assert.ok(rawFiles.length === 1, `expected 1 raw HTML file, got ${rawFiles.length.toString()}`);
+
+    // No plugin JSON should exist at the target root
+    const targetDir   = join(outDir, 'raw-only');
+    const targetFiles = await readdir(targetDir);
+    const jsonFiles   = targetFiles.filter((f: string) => f.endsWith('.json') && f !== 'failures.json');
+    assert.equal(jsonFiles.length, 0, 'no JSON output expected without a plugin step');
+  });
+
+  it('includeRawContent: false — no raw embed and _raw absent from state.page', async () => {
     const config = {
       output: { basePath: outDir },
       targets: {
@@ -164,59 +194,54 @@ describe('rawContent integration', () => {
       config:    config as Parameters<typeof ScrapeOrchestrator.scrapeHtml>[0]['config'],
     });
 
-    const files  = (await import('node:fs/promises')).readdir(join(outDir, 'raw-off'));
-    const names  = (await files).filter((f: string) => f.endsWith('.json') && f !== 'failures.json');
+    const pluginDir = join(outDir, 'raw-off', 'stub:parse');
+    const names     = (await readdir(pluginDir)).filter((f: string) => f.endsWith('.json') && f !== 'failures.json');
     assert.ok(names.length === 1, `expected 1 JSON file, got ${names.length.toString()}`);
 
     const parsed = JSON.parse(
-      await readFile(join(outDir, 'raw-off', names[0]!), 'utf8'),
+      await readFile(join(pluginDir, names[0]!), 'utf8'),
     ) as { _type: string; _raw?: unknown };
 
     assert.equal(parsed._type, 'stub');
     assert.equal(parsed._raw, undefined, '_raw must be absent when includeRawContent: false is set');
   });
 
-  it('pipeline with no plugin step produces _raw dump without plugin-specific fields', async () => {
-    // Validates Item I: a pipeline of ["html:fetch", "json:write"] with no plugin
-    // should produce output with _raw populated and no plugin-specific keys.
-    // json:write skips when output is null, so we use jsonl:append via a stub that
-    // leaves output populated — but here we test the raw fetch side only via
-    // a minimal stub that sets a bare output without plugin fields.
-    const bareStubTask: TaskFnInterface<PipelineStateInterface> = async (next, state) => {
-      state.output = {};
-      await next();
-    };
-    TaskRegistry.register('bare:stub', bareStubTask);
-
+  it('AONPRD-like full pipeline produces raw/ and stub:parse/ sibling folders', async () => {
+    // Simulates: output/aonprd/raw/Conditions.aspx-ID-1.html + output/aonprd/stub:parse/Conditions.aspx-ID-1.json
     const config = {
       output: { basePath: outDir },
       targets: {
-        'raw-no-plugin': {
-          baseUrl:  'https://fixture.test',
-          pipeline: ['html:fetch', 'bare:stub', 'json:write'],
+        'aonprd': {
+          baseUrl:  'https://2e.aonprd.com',
+          pipeline: ['html:fetch', 'html:write-raw', 'stub:parse', 'json:write'],
         },
       },
     };
 
     await ScrapeOrchestrator.scrapeHtml({
-      target:    'raw-no-plugin',
-      paths:     ['https://fixture.test/condition-blinded'],
+      target:    'aonprd',
+      paths:     ['https://2e.aonprd.com/Conditions.aspx?ID=1'],
       outDir,
       configDir: __dirname,
       config:    config as Parameters<typeof ScrapeOrchestrator.scrapeHtml>[0]['config'],
     });
 
-    const files  = (await import('node:fs/promises')).readdir(join(outDir, 'raw-no-plugin'));
-    const names  = (await files).filter((f: string) => f.endsWith('.json') && f !== 'failures.json');
-    assert.ok(names.length === 1, `expected 1 JSON file, got ${names.length.toString()}`);
+    // raw/ folder: Conditions.aspx-ID-1.html
+    const rawDir   = join(outDir, 'aonprd', 'raw');
+    const rawFiles = (await readdir(rawDir)).filter((f: string) => f.endsWith('.html'));
+    assert.ok(rawFiles.length === 1, `expected 1 raw HTML file, got ${rawFiles.length.toString()}`);
+    assert.equal(rawFiles[0], 'Conditions.aspx-ID-1.html', `expected Conditions.aspx-ID-1.html, got ${rawFiles[0] ?? '?'}`);
+
+    // stub:parse/ folder: Conditions.aspx-ID-1.json
+    const pluginDir  = join(outDir, 'aonprd', 'stub:parse');
+    const jsonFiles  = (await readdir(pluginDir)).filter((f: string) => f.endsWith('.json'));
+    assert.ok(jsonFiles.length === 1, `expected 1 plugin JSON file, got ${jsonFiles.length.toString()}`);
+    assert.equal(jsonFiles[0], 'Conditions.aspx-ID-1.json', `expected Conditions.aspx-ID-1.json, got ${jsonFiles[0] ?? '?'}`);
 
     const parsed = JSON.parse(
-      await readFile(join(outDir, 'raw-no-plugin', names[0]!), 'utf8'),
-    ) as { _raw?: RawContentInterface; _type?: unknown };
-
-    assert.ok(parsed._raw !== undefined, '_raw must be present even with no plugin');
-    assert.equal(parsed._raw.contentType, 'text/html');
-    assert.equal(parsed._raw.content, fixtureHtml, '_raw.content must match fixture HTML');
-    assert.equal(parsed._type, undefined, 'no plugin-specific _type field should be present');
+      await readFile(join(pluginDir, jsonFiles[0]!), 'utf8'),
+    ) as { _type: string; _raw?: unknown };
+    assert.equal(parsed._type, 'stub');
+    assert.equal(parsed._raw, undefined, '_raw must NOT appear in plugin JSON');
   });
 });

--- a/tests/unit/registry/builtinTasks.test.ts
+++ b/tests/unit/registry/builtinTasks.test.ts
@@ -71,7 +71,6 @@ describe('builtinTasks', () => {
       const scraper = new FakeHtmlScraper({
         url:  'https://example.test/page-resolved',
         html: '<html><body>hello</body></html>',
-        // CheerioAPI not needed for this assertion path; cast keeps the fixture lean.
         $: ((): unknown => ({}))() as unknown as ScrapedPageInterface['$'],
       });
       const state = buildState({
@@ -94,17 +93,32 @@ describe('builtinTasks', () => {
   });
 
   describe('html:write-raw', () => {
-    it('writes html to <outDir>/<target>/raw/<slug>.html', async () => {
+    it('writes html to <outDir>/<target>/raw/<url-slug>.html (URL-based filename)', async () => {
+      // URL https://example.test/page -> slug "page"
       const state = buildState({
-        page:    { targetId: TARGET, title: 'Example Page!', url: 'https://example.test/x', html: '<p>raw</p>' },
+        page:    { targetId: TARGET, title: 'Example Page!', url: 'https://example.test/page', html: '<p>raw</p>' },
         context: { target: TARGET, outDir, config: {} },
       });
       const task = TaskRegistry.get('html:write-raw');
       await task(noopNext, state);
 
-      const expected = join(outDir, TARGET, 'raw', 'example-page.html');
+      const expected = join(outDir, TARGET, 'raw', 'page.html');
       const body     = await readFile(expected, 'utf8');
       assert.equal(body, '<p>raw</p>');
+    });
+
+    it('writes html with query-string URL to <outDir>/<target>/raw/<url-slug>.html', async () => {
+      // URL https://2e.aonprd.com/Feats.aspx?ID=750 -> slug "Feats.aspx-ID-750"
+      const state = buildState({
+        page:    { targetId: TARGET, title: 'Dwarven Lore', url: 'https://2e.aonprd.com/Feats.aspx?ID=750', html: '<p>feat</p>' },
+        context: { target: TARGET, outDir, config: {} },
+      });
+      const task = TaskRegistry.get('html:write-raw');
+      await task(noopNext, state);
+
+      const expected = join(outDir, TARGET, 'raw', 'Feats.aspx-ID-750.html');
+      const body     = await readFile(expected, 'utf8');
+      assert.equal(body, '<p>feat</p>');
     });
 
     it('throws when html is missing', async () => {
@@ -117,18 +131,53 @@ describe('builtinTasks', () => {
   });
 
   describe('json:write', () => {
-    it('writes pretty JSON to <outDir>/<target>/<slug>.json with the correct slug', async () => {
+    it('writes pretty JSON to <outDir>/<target>/<url-slug>.json when no plugin task name', async () => {
+      // No pluginTaskName: file goes to <target>/<url-slug>.json
+      // URL https://x.test/page-title -> slug "page-title"
       const state = buildState({
-        page:    { targetId: TARGET, title: 'Some Title 123', url: 'https://x.test/y' },
+        page:    { targetId: TARGET, title: 'Some Title 123', url: 'https://x.test/page-title' },
         context: { target: TARGET, outDir, config: {} },
         output:  { hello: 'world' },
       });
       const task = TaskRegistry.get('json:write');
       await task(noopNext, state);
 
-      const expected = join(outDir, TARGET, 'some-title-123.json');
+      const expected = join(outDir, TARGET, 'page-title.json');
       const body     = await readFile(expected, 'utf8');
       assert.equal(body, '{\n  "hello": "world"\n}');
+    });
+
+    it('writes pretty JSON to <outDir>/<target>/<pluginTaskName>/<slug>.json when pluginTaskName is set', async () => {
+      // pluginTaskName = 'aonprd:parse', URL https://2e.aonprd.com/Feats.aspx?ID=750
+      const state = buildState({
+        page:    { targetId: TARGET, title: 'Dwarven Lore', url: 'https://2e.aonprd.com/Feats.aspx?ID=750' },
+        context: { target: TARGET, outDir, config: {}, pluginTaskName: 'aonprd:parse' },
+        output:  { _type: 'feat', name: 'Dwarven Lore' },
+      });
+      const task = TaskRegistry.get('json:write');
+      await task(noopNext, state);
+
+      const expected = join(outDir, TARGET, 'aonprd:parse', 'Feats.aspx-ID-750.json');
+      const body     = await readFile(expected, 'utf8');
+      const parsed   = JSON.parse(body) as { _type: string; name: string };
+      assert.equal(parsed._type, 'feat');
+      assert.equal(parsed.name,  'Dwarven Lore');
+    });
+
+    it('does NOT include _raw in written JSON (raw lives in raw/ folder)', async () => {
+      const raw: RawContentInterface = { contentType: 'text/html', content: '<p>hello</p>', fetchedAt: '2026-01-01T00:00:00.000Z' };
+      const state = buildState({
+        page:    { targetId: TARGET, title: 'Raw Page', url: 'https://example.test/raw-page', html: '<p>hello</p>', _raw: raw },
+        context: { target: TARGET, outDir, config: {}, pluginTaskName: 'stub:parse' },
+        output:  { name: 'Raw Page' },
+      });
+      const task = TaskRegistry.get('json:write');
+      await task(noopNext, state);
+
+      const expected = join(outDir, TARGET, 'stub:parse', 'raw-page.json');
+      const parsed   = JSON.parse(await readFile(expected, 'utf8')) as { name: string; _raw?: unknown };
+      assert.equal(parsed.name, 'Raw Page');
+      assert.equal(parsed._raw, undefined, '_raw must NOT appear in plugin JSON output');
     });
 
     it('skips writing when output is null', async () => {
@@ -138,13 +187,29 @@ describe('builtinTasks', () => {
       const task = TaskRegistry.get('json:write');
       await task(noopNext, state);
 
-      const expected = join(outDir, TARGET, 'my-page.json');
+      // With URL https://example.test/page -> slug "page"
+      const expected = join(outDir, TARGET, 'page.json');
       assert.equal(await exists(expected), false);
+    });
+
+    it('writes to <target>/<slug>.json (no subfolder) when splitByTaskName is false', async () => {
+      const state = buildState({
+        page:    { targetId: TARGET, title: 'X', url: 'https://x.test/entry' },
+        context: { target: TARGET, outDir, config: {}, pluginTaskName: 'myplugin:parse', splitByTaskName: false },
+        output:  { n: 42 },
+      });
+      const task = TaskRegistry.get('json:write');
+      await task(noopNext, state);
+
+      // splitByTaskName: false -> ignores pluginTaskName subfolder
+      const expected = join(outDir, TARGET, 'entry.json');
+      const parsed   = JSON.parse(await readFile(expected, 'utf8')) as { n: number };
+      assert.equal(parsed.n, 42);
     });
   });
 
   describe('jsonl:append', () => {
-    it('appends one JSON line per invocation to <outDir>/<target>/all.jsonl', async () => {
+    it('appends one JSON line per invocation to <outDir>/<target>/all.jsonl (no plugin)', async () => {
       const ctx  = { target: TARGET, outDir, config: {} };
       const task = TaskRegistry.get('jsonl:append');
 
@@ -155,6 +220,36 @@ describe('builtinTasks', () => {
       const expected = join(outDir, TARGET, 'all.jsonl');
       const body     = await readFile(expected, 'utf8');
       assert.equal(body, '{"n":1}\n{"n":2}\n{"n":3}\n');
+    });
+
+    it('appends to <outDir>/<target>/<pluginTaskName>/all.jsonl when pluginTaskName is set', async () => {
+      const ctx  = { target: TARGET, outDir, config: {}, pluginTaskName: 'myplugin:parse' };
+      const task = TaskRegistry.get('jsonl:append');
+
+      await task(noopNext, buildState({ context: ctx, output: { n: 1 } }));
+      await task(noopNext, buildState({ context: ctx, output: { n: 2 } }));
+
+      const expected = join(outDir, TARGET, 'myplugin:parse', 'all.jsonl');
+      const body     = await readFile(expected, 'utf8');
+      assert.equal(body, '{"n":1}\n{"n":2}\n');
+    });
+
+    it('does NOT include _raw in appended JSONL rows', async () => {
+      const raw: RawContentInterface = { contentType: 'text/html', content: '<b>bold</b>', fetchedAt: '2026-06-01T00:00:00.000Z' };
+      const ctx  = { target: TARGET, outDir, config: {}, pluginTaskName: 'stub:parse' };
+      const task = TaskRegistry.get('jsonl:append');
+
+      await task(noopNext, buildState({
+        page:    { targetId: TARGET, title: 'A', url: 'https://x.test/a', _raw: raw },
+        context: ctx,
+        output:  { n: 1 },
+      }));
+
+      const outFile = join(outDir, TARGET, 'stub:parse', 'all.jsonl');
+      const body    = await readFile(outFile, 'utf8');
+      const row     = JSON.parse(body.split('\n')[0]!) as { n: number; _raw?: unknown };
+      assert.equal(row.n, 1);
+      assert.equal(row._raw, undefined, '_raw must NOT appear in plugin JSONL output');
     });
   });
 
@@ -240,71 +335,104 @@ describe('builtinTasks', () => {
     });
   });
 
-  describe('json:write + _raw injection', () => {
-    it('includes _raw in written JSON when page._raw is set', async () => {
-      const raw: RawContentInterface = { contentType: 'text/html', content: '<p>hello</p>', fetchedAt: '2026-01-01T00:00:00.000Z' };
+  describe('URL-based filename derivation', () => {
+    it('derives slug from URL path+query (Feats.aspx?ID=750)', async () => {
+      // Feats.aspx?ID=750 -> Feats.aspx-ID-750
       const state = buildState({
-        page:    { targetId: TARGET, title: 'Raw Page', url: 'https://example.test/raw', html: '<p>hello</p>', _raw: raw },
-        context: { target: TARGET, outDir, config: { includeRawContent: true } },
-        output:  { name: 'Raw Page' },
+        page:    { targetId: TARGET, title: '', url: 'https://2e.aonprd.com/Feats.aspx?ID=750', html: '<p>feat</p>' },
+        context: { target: TARGET, outDir, config: {} },
       });
-      const task = TaskRegistry.get('json:write');
+      const task = TaskRegistry.get('html:write-raw');
       await task(noopNext, state);
-
-      const expected = join(outDir, TARGET, 'raw-page.json');
-      const parsed   = JSON.parse(await readFile(expected, 'utf8')) as { name: string; _raw?: RawContentInterface };
-      assert.equal(parsed.name, 'Raw Page');
-      assert.ok(parsed._raw !== undefined, '_raw should appear in output');
-      assert.equal(parsed._raw.contentType, 'text/html');
-      assert.equal(parsed._raw.content, '<p>hello</p>');
+      const expected = join(outDir, TARGET, 'raw', 'Feats.aspx-ID-750.html');
+      assert.equal(await exists(expected), true, `Expected file at ${expected}`);
     });
 
-    it('does not include _raw in written JSON when page._raw is absent', async () => {
+    it('derives slug from URL path+query with multiple params (Spells.aspx?ID=1042)', async () => {
       const state = buildState({
+        page:    { targetId: TARGET, title: '', url: 'https://2e.aonprd.com/Spells.aspx?ID=1042', html: '<p>spell</p>' },
         context: { target: TARGET, outDir, config: {} },
-        output:  { name: 'Plain Page' },
       });
-      const task = TaskRegistry.get('json:write');
+      const task = TaskRegistry.get('html:write-raw');
       await task(noopNext, state);
+      const expected = join(outDir, TARGET, 'raw', 'Spells.aspx-ID-1042.html');
+      assert.equal(await exists(expected), true, `Expected file at ${expected}`);
+    });
 
-      const expected = join(outDir, TARGET, 'my-page.json');
-      const parsed   = JSON.parse(await readFile(expected, 'utf8')) as { name: string; _raw?: unknown };
-      assert.equal(parsed.name, 'Plain Page');
-      assert.equal(parsed._raw, undefined);
+    it('derives slug from URL with nested path (no query)', async () => {
+      // /wiki/Goblin -> wiki-Goblin
+      const state = buildState({
+        page:    { targetId: TARGET, title: '', url: 'https://example.com/wiki/Goblin', html: '<p>g</p>' },
+        context: { target: TARGET, outDir, config: {} },
+      });
+      const task = TaskRegistry.get('html:write-raw');
+      await task(noopNext, state);
+      const expected = join(outDir, TARGET, 'raw', 'wiki-Goblin.html');
+      assert.equal(await exists(expected), true, `Expected file at ${expected}`);
+    });
+
+    it('falls back to title-based slug when URL is empty', async () => {
+      // No URL (wiki page), title = 'Goblin Warrior'
+      const state = buildState({
+        page:    { targetId: TARGET, title: 'Goblin Warrior', url: '', wikitext: '==Goblin==', html: undefined },
+        context: { target: TARGET, outDir, config: {} },
+      });
+      const task = TaskRegistry.get('wiki:write-raw');
+      await task(noopNext, state);
+      const expected = join(outDir, TARGET, 'raw', 'goblin-warrior.txt');
+      assert.equal(await exists(expected), true, `Expected file at ${expected}`);
     });
   });
 
-  describe('jsonl:append + _raw injection', () => {
-    it('includes _raw in appended JSONL rows when page._raw is set', async () => {
-      const raw: RawContentInterface = { contentType: 'text/html', content: '<b>bold</b>', fetchedAt: '2026-06-01T00:00:00.000Z' };
-      const ctx  = { target: TARGET, outDir, config: { includeRawContent: true } };
-      const task = TaskRegistry.get('jsonl:append');
+  describe('folder split — plugin vs no-plugin pipelines', () => {
+    it('json:write without plugin produces file directly under <target>/ (no subfolder)', async () => {
+      // No pluginTaskName: simulates a pipeline with no plugin step
+      const state = buildState({
+        page:    { targetId: TARGET, title: 'T', url: 'https://x.test/entry-a' },
+        context: { target: TARGET, outDir, config: {} },
+        output:  { raw_only: true },
+      });
+      const task = TaskRegistry.get('json:write');
+      await task(noopNext, state);
 
-      await task(noopNext, buildState({
-        page:    { targetId: TARGET, title: 'A', url: 'https://x.test/a', _raw: raw },
-        context: ctx,
-        output:  { n: 1 },
-      }));
-
-      const outFile = join(outDir, TARGET, 'all.jsonl');
-      const body    = await readFile(outFile, 'utf8');
-      const row     = JSON.parse(body.split('\n')[0]!) as { n: number; _raw?: RawContentInterface };
-      assert.equal(row.n, 1);
-      assert.ok(row._raw !== undefined, '_raw should appear in JSONL row');
-      assert.equal(row._raw.content, '<b>bold</b>');
+      const expected = join(outDir, TARGET, 'entry-a.json');
+      assert.equal(await exists(expected), true, `Expected ${expected}`);
+      // No plugin subfolder should exist
+      const pluginDir = join(outDir, TARGET, 'plugin');
+      assert.equal(await exists(pluginDir), false, 'No plugin subfolder when no plugin task');
     });
 
-    it('does not include _raw in appended JSONL rows when page._raw is absent', async () => {
-      const ctx  = { target: TARGET, outDir, config: {} };
-      const task = TaskRegistry.get('jsonl:append');
+    it('json:write with plugin produces file under <target>/<pluginTaskName>/ subfolder', async () => {
+      const state = buildState({
+        page:    { targetId: TARGET, title: 'T', url: 'https://x.test/entry-b' },
+        context: { target: TARGET, outDir, config: {}, pluginTaskName: 'aonprd:parse' },
+        output:  { _type: 'feat' },
+      });
+      const task = TaskRegistry.get('json:write');
+      await task(noopNext, state);
 
-      await task(noopNext, buildState({ context: ctx, output: { n: 99 } }));
+      const expected = join(outDir, TARGET, 'aonprd:parse', 'entry-b.json');
+      assert.equal(await exists(expected), true, `Expected ${expected}`);
+    });
 
-      const outFile = join(outDir, TARGET, 'all.jsonl');
-      const body    = await readFile(outFile, 'utf8');
-      const row     = JSON.parse(body.split('\n')[0]!) as { n: number; _raw?: unknown };
-      assert.equal(row.n, 99);
-      assert.equal(row._raw, undefined);
+    it('multiple plugin task names produce sibling folders', async () => {
+      const taskA = TaskRegistry.get('json:write');
+      const taskB = TaskRegistry.get('json:write');
+
+      await taskA(noopNext, buildState({
+        page:    { targetId: TARGET, title: 'X', url: 'https://x.test/r1' },
+        context: { target: TARGET, outDir, config: {}, pluginTaskName: 'aonprd-feats:parse' },
+        output:  { _type: 'feat' },
+      }));
+
+      await taskB(noopNext, buildState({
+        page:    { targetId: TARGET, title: 'Y', url: 'https://x.test/r2' },
+        context: { target: TARGET, outDir, config: {}, pluginTaskName: 'aonprd-spells:parse' },
+        output:  { _type: 'spell' },
+      }));
+
+      assert.equal(await exists(join(outDir, TARGET, 'aonprd-feats:parse', 'r1.json')),  true);
+      assert.equal(await exists(join(outDir, TARGET, 'aonprd-spells:parse', 'r2.json')), true);
     });
   });
 


### PR DESCRIPTION
## Summary

Raw and plugin-narrowed output are now written as first-class, side-by-side artifacts in parallel file trees. Raw HTML goes to `<outputBase>/<targetId>/raw/<filename>.html`; plugin JSON goes to `<outputBase>/<targetId>/<pluginTaskName>/<filename>.json`. This replaces PR #48's `_raw` embedding approach with the sibling-folder layout that was always the intended end-state.

Output layout for a target named `aonprd` with pipeline `["html:fetch", "html:write-raw", "aonprd:parse", "json:write"]`:

```
output/
  aonprd/
    raw/
      Feats.aspx-ID-750.html
      Spells.aspx-ID-1042.html
    aonprd:parse/
      Feats.aspx-ID-750.json
      Spells.aspx-ID-1042.json
```

Without a plugin step, only `raw/` is populated. The `splitByTaskName: false` escape hatch preserves flat layout. PR #48's `_raw` embedding is replaced; no version has been released with that behaviour.

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix (non-breaking fix)
- [x] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed

## Checklist

- [x] Code follows project conventions (typecheck + lint clean)
- [x] CHANGELOG.md updated under `## [Unreleased]`
- [x] No real target names introduced (target-neutrality gate passes)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] All tests pass

## Related Issues

Follows PR #48. Forward correction of the `_raw` embedding behaviour. Zero external breakage (no released version affected).

May the Omnissiah's data-streams flow through parallel conduits, raw silicon truth and parsed wisdom in their proper sacred folders.
