### PR TITLE
hotfix: remove duplicate private field (unblock 3.1.0 publish)

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
   "engines": {
     "node": ">=24.0.0"
   },
-  "private": true,
   "sideEffects": false,
   "author": "a.j.studnicky@gmail.com",
   "license": "UNLICENSED",


### PR DESCRIPTION
## Summary

The 3.1.0 publish to GitHub Packages failed with `EPRIVATE`: package.json had two `private` fields — the new `false` plus a leftover `true` — and JSON keeps the last, so npm saw `private: true`. Remove the duplicate so `@studnicky/ripperoni@3.1.0` publishes.

## Type of Change

- [x] Bug fix (packaging)

## Testing

- [x] `private` now resolves to `false`; `npm run build` + `npm run check` green at 3.1.0.

## Checklist

- [x] Conventions followed
- [x] Self-reviewed
- [x] Tests pass

## Related Issues

Unblocks the 3.1.0 GitHub Packages publish.