### PR TITLE
chore(release): 3.2.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+# Static analysis (CodeQL) for the TypeScript sources. Runs on pushes and PRs to
+# the protected branches and weekly, surfacing results under the repository's
+# Security > Code scanning tab. build-mode "none" is correct for JS/TS — CodeQL
+# analyses the sources directly without a compile step.
+
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master, develop]
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'
+
+    timeout-minutes: 15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`@studnicky/dagonizer` 0.25 adoption** — upgraded `@studnicky/dagonizer` and `@studnicky/dagonizer-executor-node` 0.24 → 0.25. Every `ScalarNode`/`MonadicNode` now declares the mandatory per-port `outputSchema` contract (a JSON Schema fragment describing the state delta each output port writes); manual `NodeContextType` literals move to `NodeContextBuilder.of(...)`; `DagContainerInterface` is no longer generic.
+- **Resilience layer — failures are first-class, classified, recovered, and reported data.** A site-agnostic set of builtin nodes composed from native dagonizer primitives (retry budget, error ports, embedded sub-DAGs), configured per target:
+  - **`FailurePolicy` + `route:failure`** — `html:fetch` stashes a structured failure context and the `route:failure` node consults a pluggable `FailurePolicy` to route `retry | resolve | capture | expected`. The default policy retries *transient* errors (5xx/429/network) on a bounded self-loop via the native `recordAttempt` budget and captures *permanent* 4xx (404) immediately — no wasted requests. Sits above the per-request `HttpRetryPolicy` as a coarser, flow-visible layer.
+  - **`error:capture`** — projects the `NodeError`s on `state.errors` into `state.output` as an `{ _type: 'error', url, errors }` document that `json:write` persists, so a failing page is inspectable data on disk instead of vanishing into an opaque scatter error partition (otherwise unrecoverable across the worker boundary).
+  - **`reconcile:identity` + `report:crawl-health`** — post-crawl nodes that build an identity index from captured concepts via a fully pluggable `Reconciler` (`prepare(concepts) → index`, `resolveFailure(failure, index)`), reclassify each failure as `capturedElsewhere | missing | dead`, and write a `crawl-health.json` audit manifest (totals + `missing[]` + `capturedElsewhere[]`). The AON reconciler matches a broken cross-category link by its preserved id + originating link text, resolving e.g. the mislinked `Classes.aspx?ID=77` "catfolk" to the captured `Ancestries.aspx?ID=77` ancestry — proving data completeness automatically at scale.
+  - **`resolve:link`** (opt-in) — on `route:failure → resolve`, ordered `LinkResolverStrategy` implementations (`crossLocator` probes sibling categories for the same id; `search`; `canonical`) recover a wrong-locator link and re-fetch the corrected url, bounded by a resolve budget. Dormant unless a target supplies `services.resolve`.
+- **CodeQL static analysis** — `.github/workflows/codeql.yml` runs the `security-extended` query suite over the TypeScript sources on every push/PR to the protected branches and weekly, surfacing findings under Security > Code scanning.
+
+### Fixed
+
+- **Worker-thread DAG assets** — `scripts/copy-dag-assets.mjs` now mirrors `.dag.jsonld` documents into `dist-workers/` (both the `src/` builtins and the `plugins/` documents), not only `dist/`. Without them a `WorkerThreadContainer` crashed on init (`DagHost init failed: ENOENT … crawl-discover.dag.jsonld`), so the parallel (`parallelWorkers: true`) scrape path produced no output. The parallel rip now fetches, parses, and writes correctly.
+
+### Changed
+
+- **Dependency refresh** — `@types/node` 25 → 26, `commander` 14 → 15, `typescript-eslint` 8.59 → 8.61.
+- **Cleared all Dependabot alerts** — `overrides` pin `vite` to `^6.4.3` and `esbuild` to `^0.25.0`, replacing the vulnerable `vite@5`/`esbuild@0.21` that VitePress 1.6.4 pulls transitively. `npm audit` reports zero vulnerabilities; the docs build and dev server both verified on vite 6. These are dev-only (docs toolchain) dependencies and never shipped in `dist/`.
+
 ## [3.1.1] - 2026-06-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-06-21
+
 ### Added
 
 - **`@studnicky/dagonizer` 0.25 adoption** — upgraded `@studnicky/dagonizer` and `@studnicky/dagonizer-executor-node` 0.24 → 0.25. Every `ScalarNode`/`MonadicNode` now declares the mandatory per-port `outputSchema` contract (a JSON Schema fragment describing the state delta each output port writes); manual `NodeContextType` literals move to `NodeContextBuilder.of(...)`; `DagContainerInterface` is no longer generic.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/Studnicky/Ripperoni/actions/workflows/ci.yml/badge.svg)](https://github.com/Studnicky/Ripperoni/actions/workflows/ci.yml)
 [![docs](https://img.shields.io/badge/docs-studnicky.github.io-c8284a)](https://studnicky.github.io/Ripperoni/)
 [![node](https://img.shields.io/badge/node-%3E%3D24-brightgreen)](package.json)
-[![version](https://img.shields.io/badge/version-3.1.1-c8284a)](CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.2.0-c8284a)](CHANGELOG.md)
 
 ## Documentation
 

--- a/aonprd.dag.jsonld
+++ b/aonprd.dag.jsonld
@@ -115,10 +115,28 @@
       },
       "reducer": "aggregate",
       "outputs": {
-        "all-success": "done",
-        "partial": "done",
-        "all-error": "done",
-        "empty": "done"
+        "all-success": "reconcile:identity",
+        "partial": "reconcile:identity",
+        "all-error": "reconcile:identity",
+        "empty": "reconcile:identity"
+      }
+    },
+    {
+      "@id": "urn:noocodex:dag:aonprd:crawl/node/reconcile-identity",
+      "@type": "SingleNode",
+      "name": "reconcile:identity",
+      "node": "reconcile:identity",
+      "outputs": {
+        "done": "report:crawl-health"
+      }
+    },
+    {
+      "@id": "urn:noocodex:dag:aonprd:crawl/node/report-crawl-health",
+      "@type": "SingleNode",
+      "name": "report:crawl-health",
+      "node": "report:crawl-health",
+      "outputs": {
+        "done": "done"
       }
     },
     {

--- a/examples/docs-scraper/output/architecture.json
+++ b/examples/docs-scraper/output/architecture.json
@@ -4,36 +4,36 @@
       "_type": "docs_section",
       "component": "pipeline",
       "title": "DAG dispatch ​",
-      "description": "Directed acyclic graph orchestration powered by @noocodex/dagonizer — every node declares named output ports, fan-out handles concurrency, and state flows checkpoint-ready through the run.",
-      "url": "http://127.0.0.1:65381/architecture.html"
+      "description": "Directed acyclic graph orchestration powered by @studnicky/dagonizer — every node declares named output ports, scatter handles concurrency, and state flows checkpoint-ready through the run.",
+      "url": "http://127.0.0.1:59034/architecture.html"
     },
     {
       "_type": "docs_section",
       "component": "http-layer",
       "title": "HTTP machinery ​",
-      "description": "Three composable classes — RateLimiter, RetryExecutor, and ErrorClassifier — form the HTTP stack, each injected independently.",
-      "url": "http://127.0.0.1:65381/architecture.html"
+      "description": "Three composable classes — RateLimiter, HttpRetryPolicy, and ErrorClassifier — form the HTTP stack, each injected independently.",
+      "url": "http://127.0.0.1:59034/architecture.html"
     },
     {
       "_type": "docs_section",
       "component": "scrapers",
       "title": "Scrapers ​",
-      "description": "Pure data accessors for HTML (via cheerio) and MediaWiki (via native fetch) that return typed results without coupling to the pipeline.",
-      "url": "http://127.0.0.1:65381/architecture.html"
+      "description": "Pure data accessors for HTML (via cheerio) and MediaWiki (via native fetch) that return typed results without coupling to the DAG graph.",
+      "url": "http://127.0.0.1:59034/architecture.html"
     },
     {
       "_type": "docs_section",
       "component": "crawler",
       "title": "Link crawler ​",
       "description": "Recursive link crawler controlled by three regexes (domain, delimiter, target) that bound traversal and collect matching URLs.",
-      "url": "http://127.0.0.1:65381/architecture.html"
+      "url": "http://127.0.0.1:59034/architecture.html"
     },
     {
       "_type": "docs_section",
       "component": "source-map",
       "title": "Source map ​",
-      "description": "Complete index of every source file, its exported symbols, and the PathRipper or TORUS module it was ported from.",
-      "url": "http://127.0.0.1:65381/architecture.html"
+      "description": "Complete index of every source module, its primary exports, and its role in the scrape run.",
+      "url": "http://127.0.0.1:59034/architecture.html"
     }
   ]
 }

--- a/examples/docs-scraper/plugin.js
+++ b/examples/docs-scraper/plugin.js
@@ -9,6 +9,20 @@ import { DAGBuilder, ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer'
 class DocsParseNodeImpl extends ScalarNode {
     name = 'docs:parse-impl';
     outputs = ['success'];
+    get outputSchema() {
+        return {
+            // `success` — `state.output` is set to the first extracted section or a
+            // fallback page-level object; `state.metadata.sections` may hold all
+            // extracted sections.
+            success: {
+                type: 'object',
+                properties: {
+                    output: { type: 'object' },
+                },
+                required: ['output'],
+            },
+        };
+    }
     async executeOne(state, _context) {
         const html = state.page.html ?? '';
         const url = state.page.url;

--- a/examples/docs-scraper/plugin.ts
+++ b/examples/docs-scraper/plugin.ts
@@ -8,7 +8,7 @@
 import { load } from 'cheerio';
 
 import { DAGBuilder, ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType, DAGType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, DAGType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { RipperDagonizer } from '../../src/dispatcher/RipperDagonizer.js';
 import type { ScrapeState }     from '../../src/state/ScrapeState.js';
@@ -33,6 +33,21 @@ type DocsOutput = DocsSectionOutput | DocsPageOutput;
 class DocsParseNodeImpl extends ScalarNode<ScrapeState, 'success', RipperServices> {
   public readonly name    = 'docs:parse-impl';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — `state.output` is set to the first extracted section or a
+      // fallback page-level object; `state.metadata.sections` may hold all
+      // extracted sections.
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state:    ScrapeState,

--- a/examples/wiki-docs/plugin.js
+++ b/examples/wiki-docs/plugin.js
@@ -11,6 +11,19 @@ const TEMPLATE_MARKER = '{{RipperoniComponent';
 class WikiDocsParseNodeImpl extends ScalarNode {
     name = 'wiki-docs:parse-impl';
     outputs = ['success'];
+    get outputSchema() {
+        return {
+            // `success` — `state.output` is set to either a `ripperoni_component`
+            // object (when the template is found) or a `raw_page` fallback.
+            success: {
+                type: 'object',
+                properties: {
+                    output: { type: 'object' },
+                },
+                required: ['output'],
+            },
+        };
+    }
     async executeOne(state, _context) {
         const wikitext = state.page.wikitext ?? '';
         const title = state.page.title;

--- a/examples/wiki-docs/plugin.ts
+++ b/examples/wiki-docs/plugin.ts
@@ -9,7 +9,7 @@
 import wtf from 'wtf_wikipedia';
 
 import { DAGBuilder, ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType, DAGType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, DAGType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { RipperDagonizer } from '../../src/dispatcher/RipperDagonizer.js';
 import type { ScrapeState }     from '../../src/state/ScrapeState.js';
@@ -35,6 +35,20 @@ interface RawPageOutput {
 class WikiDocsParseNodeImpl extends ScalarNode<ScrapeState, 'success', RipperServices> {
   public readonly name    = 'wiki-docs:parse-impl';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — `state.output` is set to either a `ripperoni_component`
+      // object (when the template is found) or a `raw_page` fallback.
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state:    ScrapeState,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
-  "name": "ripperoni",
-  "version": "3.0.0",
+  "name": "@studnicky/ripperoni",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ripperoni",
-      "version": "3.0.0",
+      "name": "@studnicky/ripperoni",
+      "version": "3.1.1",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
-        "@studnicky/dagonizer": "^0.24.0",
-        "@studnicky/dagonizer-executor-node": "^0.24.0",
+        "@studnicky/dagonizer": "^0.25.0",
+        "@studnicky/dagonizer-executor-node": "^0.25.0",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
         "bottleneck": "^2.19.5",
         "cheerio": "^1.0.0",
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "domhandler": "^6.0.1",
         "json-schema-to-ts": "^3.1.1",
         "wtf_wikipedia": "^10.3.0"
@@ -26,7 +26,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/node": "^25.6.0",
+        "@types/node": "^26.0.0",
         "cytoscape": "^3.34.0",
         "eslint": "^10.3.0",
         "globals": "^17.6.0",
@@ -34,7 +34,7 @@
         "sharp": "^0.35.2",
         "tsx": "^4.0.0",
         "typescript": "^6.0.3",
-        "typescript-eslint": "8.59.2",
+        "typescript-eslint": "^8.61.1",
         "vitepress": "^1.6.4",
         "vitepress-plugin-mermaid": "^2.0.17",
         "vue": "^3.0.0"
@@ -465,448 +465,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2139,9 +1697,9 @@
       "license": "MIT"
     },
     "node_modules/@studnicky/dagonizer": {
-      "version": "0.24.0",
-      "resolved": "https://npm.pkg.github.com/download/@studnicky/dagonizer/0.24.0/6dbc298dfed6df4870adafc0488ecc8aec6a104d",
-      "integrity": "sha512-KkZQb1/utr1z2QxJyVcumDDb+8CfxB+UZcGafBcOzR55mnsrhuaTYElGYWohNvnzIdxy5zpC4y0GjA14VVp1sA==",
+      "version": "0.25.0",
+      "resolved": "https://npm.pkg.github.com/download/@studnicky/dagonizer/0.25.0/0def4bacd1a843e2f97c7d9735c9f895d46e68ca",
+      "integrity": "sha512-UknYSKwvZgD4gvlcp8DX54y7J25oT/HRs26MuDdyxvV6dsL3ArEQzAjHFisZbj3R4Q2+VsnzhAmyMXw8Q3IP5g==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.20.0",
@@ -2156,12 +1714,12 @@
       }
     },
     "node_modules/@studnicky/dagonizer-executor-node": {
-      "version": "0.24.0",
-      "resolved": "https://npm.pkg.github.com/download/@studnicky/dagonizer-executor-node/0.24.0/193b31b0c08e20f33f489724935ff8c08c0063c4",
-      "integrity": "sha512-bRZ8+NJNcRYcW/dYSOxVh4CdbJ2xxr4TVciBI5KKtxCzksrjPaiAkIchHy12oiwi5o4/tqySydVCezh9J0If3w==",
+      "version": "0.25.0",
+      "resolved": "https://npm.pkg.github.com/download/@studnicky/dagonizer-executor-node/0.25.0/c447b5b480637d59364c7c344dc407a28da592d6",
+      "integrity": "sha512-KNrZTPRvB6qvw54LswRi+eRuq4Eo5HuULz4l1rvTXTDKwOVN2vGD9U52rIlb6gPQHXRTOhuVYvIvestu7xVJSw==",
       "license": "MIT",
       "dependencies": {
-        "@studnicky/dagonizer": ">=0.24.0"
+        "@studnicky/dagonizer": ">=0.25.0"
       },
       "engines": {
         "node": ">=24"
@@ -2525,14 +2083,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
-      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -2558,17 +2116,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
-      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
+      "integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/type-utils": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/type-utils": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2581,7 +2139,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.2",
+        "@typescript-eslint/parser": "^8.61.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2597,17 +2155,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
-      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
+      "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2623,14 +2181,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
-      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+      "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.2",
-        "@typescript-eslint/types": "^8.59.2",
+        "@typescript-eslint/tsconfig-utils": "^8.61.1",
+        "@typescript-eslint/types": "^8.61.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2645,14 +2203,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
-      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+      "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2"
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2663,9 +2221,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
-      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+      "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2680,15 +2238,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
-      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
+      "integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2705,9 +2263,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
-      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2719,16 +2277,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
-      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+      "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.2",
-        "@typescript-eslint/tsconfig-utils": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/project-service": "8.61.1",
+        "@typescript-eslint/tsconfig-utils": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2747,16 +2305,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
-      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
+      "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2"
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2771,13 +2329,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
-      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+      "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/types": "8.61.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -3330,12 +2888,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/copy-anything": {
@@ -4210,48 +3768,6 @@
         "docs",
         "benchmarks"
       ]
-    },
-    "node_modules/esbuild": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.1",
-        "@esbuild/android-arm": "0.28.1",
-        "@esbuild/android-arm64": "0.28.1",
-        "@esbuild/android-x64": "0.28.1",
-        "@esbuild/darwin-arm64": "0.28.1",
-        "@esbuild/darwin-x64": "0.28.1",
-        "@esbuild/freebsd-arm64": "0.28.1",
-        "@esbuild/freebsd-x64": "0.28.1",
-        "@esbuild/linux-arm": "0.28.1",
-        "@esbuild/linux-arm64": "0.28.1",
-        "@esbuild/linux-ia32": "0.28.1",
-        "@esbuild/linux-loong64": "0.28.1",
-        "@esbuild/linux-mips64el": "0.28.1",
-        "@esbuild/linux-ppc64": "0.28.1",
-        "@esbuild/linux-riscv64": "0.28.1",
-        "@esbuild/linux-s390x": "0.28.1",
-        "@esbuild/linux-x64": "0.28.1",
-        "@esbuild/netbsd-arm64": "0.28.1",
-        "@esbuild/netbsd-x64": "0.28.1",
-        "@esbuild/openbsd-arm64": "0.28.1",
-        "@esbuild/openbsd-x64": "0.28.1",
-        "@esbuild/openharmony-arm64": "0.28.1",
-        "@esbuild/sunos-x64": "0.28.1",
-        "@esbuild/win32-arm64": "0.28.1",
-        "@esbuild/win32-ia32": "0.28.1",
-        "@esbuild/win32-x64": "0.28.1"
-      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -5902,6 +5418,490 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5931,16 +5931,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
-      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
+      "integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.2",
-        "@typescript-eslint/parser": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2"
+        "@typescript-eslint/eslint-plugin": "8.61.1",
+        "@typescript-eslint/parser": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5964,9 +5964,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6104,22 +6104,25 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -6128,17 +6131,23 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
         "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
-        "terser": "^5.4.0"
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
+          "optional": true
+        },
+        "jiti": {
           "optional": true
         },
         "less": {
@@ -6161,13 +6170,19 @@
         },
         "terser": {
           "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
         }
       }
     },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
@@ -6178,13 +6193,13 @@
         "aix"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
@@ -6195,13 +6210,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
@@ -6212,13 +6227,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
@@ -6229,13 +6244,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
@@ -6246,13 +6261,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
@@ -6263,13 +6278,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
@@ -6280,13 +6295,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
@@ -6297,13 +6312,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
@@ -6314,13 +6329,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
@@ -6331,13 +6346,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
@@ -6348,13 +6363,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
@@ -6365,13 +6380,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
@@ -6382,13 +6397,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
@@ -6399,13 +6414,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
@@ -6416,13 +6431,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
@@ -6433,13 +6448,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
@@ -6450,13 +6465,30 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
@@ -6467,13 +6499,30 @@
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
@@ -6484,13 +6533,30 @@
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
       ],
@@ -6501,13 +6567,13 @@
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
@@ -6518,13 +6584,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
@@ -6535,13 +6601,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
@@ -6552,13 +6618,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6566,32 +6632,35 @@
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/vitepress": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studnicky/ripperoni",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Web ingestion engine; slices wikis, sites, and URL lists into JSON records, one page at a time. Pairs with Squashage for RDF graph reconstitution.",
   "type": "module",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -62,20 +62,20 @@
     "docs:preview": "vitepress preview docs"
   },
   "dependencies": {
-    "@studnicky/dagonizer": "^0.24.0",
-    "@studnicky/dagonizer-executor-node": "^0.24.0",
+    "@studnicky/dagonizer": "^0.25.0",
+    "@studnicky/dagonizer-executor-node": "^0.25.0",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
     "bottleneck": "^2.19.5",
     "cheerio": "^1.0.0",
-    "commander": "^14.0.3",
+    "commander": "^15.0.0",
     "domhandler": "^6.0.1",
     "json-schema-to-ts": "^3.1.1",
     "wtf_wikipedia": "^10.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/node": "^25.6.0",
+    "@types/node": "^26.0.0",
     "cytoscape": "^3.34.0",
     "eslint": "^10.3.0",
     "globals": "^17.6.0",
@@ -83,7 +83,7 @@
     "sharp": "^0.35.2",
     "tsx": "^4.0.0",
     "typescript": "^6.0.3",
-    "typescript-eslint": "8.59.2",
+    "typescript-eslint": "^8.61.1",
     "vitepress": "^1.6.4",
     "vitepress-plugin-mermaid": "^2.0.17",
     "vue": "^3.0.0"
@@ -100,5 +100,9 @@
       "bingSiteVerification": "",
       "twitterHandle": ""
     }
+  },
+  "overrides": {
+    "vite": "^6.4.3",
+    "esbuild": "^0.25.0"
   }
 }

--- a/plugins/_test_secondary/concepts/sample.ts
+++ b/plugins/_test_secondary/concepts/sample.ts
@@ -5,8 +5,8 @@
 // can be reused with a non-AON strategy. The finalize node reads the
 // projected `aonprdCommon.sections` / `.sources` that the secondary strategy
 // populated and emits a minimal output shape.
-import { ScalarNode, NodeOutputBuilder }      from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import { ScalarNode, NodeOutputBuilder }                        from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
 import type { CommonExtraction } from '../../aonprd/common.js';
@@ -25,6 +25,20 @@ export interface SampleOutput {
 class FinalizeSampleNodeImpl extends ScalarNode<ScrapeState, 'success'> {
   public readonly name    = 'finalize:sample';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — `state.output` is merged with the assembled `SampleOutput`
+      // object drawn from `aonprdCommon` metadata.
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/_test_secondary/parse.task.ts
+++ b/plugins/_test_secondary/parse.task.ts
@@ -4,17 +4,12 @@
 // SECONDARY taxonomy. Demonstrates the AONPRD Layer-1 capabilities binary
 // is plugin-agnostic when paired with a plugin-supplied `CommonStrategy`.
 import { Batch }                from '@studnicky/dagonizer';
-import type { NodeContextType } from '@studnicky/dagonizer';
+import { NodeContextBuilder } from '@studnicky/dagonizer/entities';
 
 import { ScrapeState } from '../../src/state/ScrapeState.js';
 import { TAXONOMY } from './taxonomy.js';
 
-const STUB_CONTEXT: NodeContextType = {
-  services: undefined,
-  signal:   new AbortController().signal,
-  dagName:  'secondary:parse:direct',
-  nodeName: 'secondary:parse:direct',
-};
+const STUB_CONTEXT = NodeContextBuilder.of('secondary:parse:direct', 'secondary:parse:direct', new AbortController().signal, undefined);
 
 /**
  * Parse a secondary-source HTML page via the compiled secondary taxonomy.

--- a/plugins/aonprd/AonprdReconciler.ts
+++ b/plugins/aonprd/AonprdReconciler.ts
@@ -1,0 +1,115 @@
+/**
+ * AonprdReconciler — AON-specific identity reconciliation.
+ *
+ * Builds a two-map index from captured concept docs:
+ *   - `nameIdToUrl`  — `name|id` → URL where that concept was captured.
+ *   - `hrefToTexts`  — relative href → all link text strings that point to it.
+ *
+ * AON's broken cross-category links preserve the numeric `ID` (e.g. the catfolk
+ * ancestry at `Ancestries.aspx?ID=77` is mislinked as `Classes.aspx?ID=77`).
+ * A failure is resolved `capturedElsewhere` only when a captured concept matches
+ * BOTH the originating link text (name) AND the id — so "catfolk" + id 77 lands
+ * on the ancestry, never on a same-named "Catfolk" trait at a different id.
+ * Otherwise `missing`.
+ *
+ * @module plugins/aonprd/AonprdReconciler
+ * @since 3.3.0
+ */
+
+import type {
+  ReconcilerInterface,
+  CapturedConceptType,
+  CapturedFailureType,
+  ResolutionType,
+} from '../../src/resilience/Reconciler.js';
+
+// ── AonprdIndexType ────────────────────────────────────────────────────────────
+
+type AonprdIndexType = {
+  readonly nameIdToUrl: ReadonlyMap<string, string>;
+  readonly hrefToTexts: ReadonlyMap<string, readonly string[]>;
+};
+
+// ── AonprdReconciler ───────────────────────────────────────────────────────────
+
+export class AonprdReconciler implements ReconcilerInterface<AonprdIndexType> {
+  public prepare(concepts: readonly CapturedConceptType[]): AonprdIndexType {
+    const nameIdToUrl = new Map<string, string>();
+    const hrefToTexts = new Map<string, string[]>();
+
+    for (const concept of concepts) {
+      // Build nameIdToUrl: `name|id` → url. The id is taken from the captured
+      // url so it is comparable to a broken link's id (both are `?ID=n`).
+      const name = concept.output['name'];
+      const id   = AonprdReconciler.idOf(concept.url);
+      if (typeof name === 'string' && id !== null) {
+        nameIdToUrl.set(AonprdReconciler.nameIdKey(name, id), concept.url);
+      }
+
+      // Build hrefToTexts: relHref from each link in output.links → text[]
+      // output.links entries shape: { href: string, text: string, kind: string, id: number|null }
+      const links = concept.output['links'];
+      if (Array.isArray(links)) {
+        for (const entry of links as Array<Record<string, unknown>>) {
+          if (typeof entry['href'] !== 'string' || typeof entry['text'] !== 'string') continue;
+          const rel = AonprdReconciler.relHref(entry['href'] as string);
+          const txt = AonprdReconciler.normalize(entry['text'] as string);
+          if (txt !== '') {
+            const existing = hrefToTexts.get(rel);
+            if (existing !== undefined) {
+              existing.push(txt);
+            } else {
+              hrefToTexts.set(rel, [txt]);
+            }
+          }
+        }
+      }
+    }
+
+    return { nameIdToUrl, hrefToTexts };
+  }
+
+  public resolveFailure(failure: CapturedFailureType, index: AonprdIndexType): ResolutionType {
+    const id = AonprdReconciler.idOf(failure.url);
+    if (id === null) return { status: 'missing' };
+    const href  = AonprdReconciler.relHref(failure.url);
+    const texts = index.hrefToTexts.get(href) ?? [];
+    for (const text of texts) {
+      // Require BOTH the link text (name) AND the preserved id to match — this
+      // disambiguates a mislabeled cross-category link from a coincidental
+      // same-name concept at a different id.
+      const at = index.nameIdToUrl.get(AonprdReconciler.nameIdKey(text, id));
+      if (at !== undefined) return { status: 'capturedElsewhere', at };
+    }
+    return { status: 'missing' };
+  }
+
+  /** Composite lookup key: normalized name + numeric id. */
+  private static nameIdKey(name: string, id: number): string {
+    return `${AonprdReconciler.normalize(name)}|${id.toString()}`;
+  }
+
+  /** Normalize a concept name for lookup: trim + lowercase. */
+  private static normalize(name: string): string {
+    return name.trim().toLowerCase();
+  }
+
+  /** Extract the numeric `?ID=n` from an AON url, or `null` when absent. */
+  private static idOf(url: string): number | null {
+    const match = /[?&]ID=(\d+)/i.exec(url);
+    return match !== null ? Number.parseInt(match[1] as string, 10) : null;
+  }
+
+  /**
+   * Strip origin and leading slash from a URL, leaving just the relative href.
+   * "https://2e.aonprd.com/Classes.aspx?ID=77" → "Classes.aspx?ID=77"
+   * "Classes.aspx?ID=77" → "Classes.aspx?ID=77"
+   */
+  private static relHref(url: string): string {
+    const match = /^https?:\/\/[^/]+\/(.+)$/.exec(url);
+    return match !== null ? (match[1] as string) : url.replace(/^\//, '');
+  }
+}
+
+/** Singleton AON reconciler instance. */
+export const aonprdReconciler = new AonprdReconciler();

--- a/plugins/aonprd/capabilities/labelPairBlock.ts
+++ b/plugins/aonprd/capabilities/labelPairBlock.ts
@@ -6,7 +6,7 @@
 // re-extraction is gone. `extractCommon` is the sole producer of
 // the harvested header data; this capability is a pure projection.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import { CAPABILITY_OUTPUTS } from '../common.js';
 
 import type { ScrapeState }     from '../../../src/state/ScrapeState.js';
@@ -17,6 +17,16 @@ export type LabelPairBlockOutput = 'success' | 'error';
 class LabelPairBlockNode extends ScalarNode<ScrapeState, LabelPairBlockOutput> {
   public readonly name = 'extract:label-pair-block';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<LabelPairBlockOutput, SchemaObjectType> {
+    return {
+      // `success` — writes `field_map` (Record<string,string>) and `fields` (string[]) to metadata.
+      // No state.output delta; metadata keys 'field_map' and 'fields' are set.
+      success: { type: 'object' },
+      // `error` — never emitted (open-world soft-fail to success); no state delta.
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/capabilities/metaTags.ts
+++ b/plugins/aonprd/capabilities/metaTags.ts
@@ -10,7 +10,7 @@
 // Open-world convention: soft-fail to `'success'` with no writes when
 // `aonprdCheerio` is absent (e.g. rule pages whose load short-circuits).
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -27,6 +27,14 @@ export type MetaTagsOutput = 'success';
 class MetaTagsNode extends ScalarNode<ScrapeState, MetaTagsOutput> {
   public readonly name = 'extract:meta-tags';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<MetaTagsOutput, SchemaObjectType> {
+    return {
+      // `success` — writes `aonprdMetaTags` metadata key: { description: string|null, keywords: string|null }.
+      // No state.output delta; soft-fails with no writes when `aonprdCheerio` is absent.
+      success: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/capabilities/savingThrow.ts
+++ b/plugins/aonprd/capabilities/savingThrow.ts
@@ -11,7 +11,7 @@
 //
 // Lifted into a shared capability to eliminate duplicate parsers across concept files.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { ScrapeState } from '../../../src/state/ScrapeState.js';
 import type { CommonExtraction } from '../common.js';
@@ -62,6 +62,14 @@ export type SavingThrowOutput = 'success';
 class SavingThrowNodeImpl extends ScalarNode<ScrapeState, SavingThrowOutput> {
   public readonly name    = 'extract:saving-throw';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<SavingThrowOutput, SchemaObjectType> {
+    return {
+      // `success` — writes `aonprdSavingThrow` metadata key: { dc: number|null, save: string|null, basic: boolean }.
+      // No state.output delta; soft-fails with no writes when field is absent.
+      success: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/capabilities/sectionWalker.ts
+++ b/plugins/aonprd/capabilities/sectionWalker.ts
@@ -6,7 +6,7 @@
 // re-extraction is gone. `extractCommon` is the sole producer of
 // the harvested section list; this capability is a pure projection.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import { CAPABILITY_OUTPUTS } from '../common.js';
 
 import type { ScrapeState }      from '../../../src/state/ScrapeState.js';
@@ -17,6 +17,16 @@ export type SectionWalkerOutput = 'success' | 'error';
 class SectionWalkerNodeImpl extends ScalarNode<ScrapeState, SectionWalkerOutput> {
   public readonly name = 'extract:section-walker';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<SectionWalkerOutput, SchemaObjectType> {
+    return {
+      // `success` — writes `sections` metadata key: Section[] (array of {heading,level,body_html,body_text,links}).
+      // No state.output delta; soft-fails to success with no writes when `aonprdCommon` is absent.
+      success: { type: 'object' },
+      // `error` — never emitted (open-world soft-fail to success); no state delta.
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/capabilities/sourceRef.ts
+++ b/plugins/aonprd/capabilities/sourceRef.ts
@@ -6,7 +6,7 @@
 // re-extraction is gone. `extractCommon` is the sole producer of
 // the source reference list; this capability is a pure projection.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import { CAPABILITY_OUTPUTS } from '../common.js';
 
 import type { ScrapeState }      from '../../../src/state/ScrapeState.js';
@@ -17,6 +17,16 @@ export type SourceRefOutput = 'success' | 'error';
 class SourceRefNode extends ScalarNode<ScrapeState, SourceRefOutput> {
   public readonly name = 'extract:source-ref';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<SourceRefOutput, SchemaObjectType> {
+    return {
+      // `success` — writes `sources` (SourceRef[]) and `source` ({ book, page, source_id }) metadata keys.
+      // No state.output delta; soft-fails to success with no writes when `aonprdCommon` is absent.
+      success: { type: 'object' },
+      // `error` — never emitted (open-world soft-fail to success); no state delta.
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/action.ts
+++ b/plugins/aonprd/concepts/action.ts
@@ -3,7 +3,7 @@
 // data including skill refs, four-tier outcome blocks, and
 // trigger/frequency/requirements fields.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -253,6 +253,35 @@ class ActionBaseNodeImpl extends ScalarNode<ScrapeState, ActionBaseOutput> {
   public readonly name = 'extract:action-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<ActionBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              url:             { type: 'string' },
+              action_id:       { type: ['integer', 'null'] },
+              name:            { type: 'string' },
+              rarity:          { type: 'string' },
+              action_cost:     { type: ['string', 'null'] },
+              traits:          { type: 'array', items: { type: 'string' } },
+              trait_ids:       { type: 'object' },
+              source:          { type: 'object' },
+              sources:         { type: 'array', items: { type: 'object' } },
+              legacy:          { type: 'boolean' },
+              alt_edition_url: { type: ['string', 'null'] },
+            },
+            required: ['url', 'name', 'rarity', 'traits', 'trait_ids', 'source', 'sources', 'legacy'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -277,6 +306,31 @@ class ActionEffectNodeImpl extends ScalarNode<ScrapeState, ActionEffectOutput> {
   public readonly name = 'extract:action-effect';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<ActionEffectOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              trigger:      { type: ['string', 'null'] },
+              frequency:    { type: ['string', 'null'] },
+              requirements: { type: ['string', 'null'] },
+              cost:         { type: ['string', 'null'] },
+              effect_html:  { type: 'string' },
+              effect_text:  { type: 'string' },
+              outcomes:     { type: 'object' },
+            },
+            required: ['effect_html', 'effect_text', 'outcomes'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -300,6 +354,20 @@ export type FinalizeActionOutput = 'success';
 class FinalizeActionNodeImpl extends ScalarNode<ScrapeState, FinalizeActionOutput> {
   public readonly name = 'finalize:action';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeActionOutput, SchemaObjectType> {
+    return {
+      // `success` — calls setConceptOutput(state, assembled): writes state.output as the complete ActionOutput,
+      // which includes all ActionBaseSlice + ActionEffectSlice fields plus skill, raw_fields, links, meta_description, meta_keywords.
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/ancestry.ts
+++ b/plugins/aonprd/concepts/ancestry.ts
@@ -7,7 +7,7 @@
 //
 // partial extraction and incremental composition in the taxonomy pipeline.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -394,6 +394,38 @@ class AncestryBaseNode extends ScalarNode<ScrapeState, AncestryBaseOutput> {
   public readonly name = 'extract:ancestry-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<AncestryBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              url:              { type: 'string' },
+              ancestry_id:      { type: ['integer', 'null'] },
+              name:             { type: 'string' },
+              rarity:           { type: 'string' },
+              pfs:              { type: ['string', 'null'] },
+              legacy:           { type: 'boolean' },
+              alt_edition_url:  { type: ['string', 'null'] },
+              traits:           { type: 'array', items: { type: 'string' } },
+              trait_ids:        { type: 'object' },
+              source:           { type: 'object' },
+              sources:          { type: 'array', items: { type: 'object' } },
+              mechanics:        { type: 'object' },
+              popular_edicts:   { type: ['string', 'null'] },
+              popular_anathema: { type: ['string', 'null'] },
+            },
+            required: ['url', 'name', 'rarity', 'traits', 'trait_ids', 'source', 'sources', 'mechanics'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -424,6 +456,35 @@ class AncestryHeritagesNode extends ScalarNode<ScrapeState, AncestryHeritagesOut
   public readonly name = 'extract:ancestry-heritages';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<AncestryHeritagesOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              heritages: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    name:        { type: 'string' },
+                    description: { type: 'string' },
+                  },
+                  required: ['name', 'description'],
+                },
+              },
+            },
+            required: ['heritages'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -451,6 +512,36 @@ export type AncestryFeaturesOutput = 'success' | 'error';
 class AncestryFeaturesNode extends ScalarNode<ScrapeState, AncestryFeaturesOutput> {
   public readonly name = 'extract:ancestry-features';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<AncestryFeaturesOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              initial_proficiencies: { type: 'object' },
+              features: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    name:        { type: 'string' },
+                    description: { type: 'string' },
+                  },
+                  required: ['name', 'description'],
+                },
+              },
+            },
+            required: ['initial_proficiencies', 'features'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -480,6 +571,19 @@ export type FinalizeAncestryOutput = 'success';
 class FinalizeAncestryNode extends ScalarNode<ScrapeState, FinalizeAncestryOutput> {
   public readonly name = 'finalize:ancestry';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeAncestryOutput, SchemaObjectType> {
+    return {
+      // `success` — calls setConceptOutput(state, assembled): writes state.output as the complete AncestryOutput.
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/animal-companion/nodes.ts
+++ b/plugins/aonprd/concepts/animal-companion/nodes.ts
@@ -1,6 +1,6 @@
 // Animal-companion capability nodes.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 import type { ScrapeState } from '../../../../src/state/ScrapeState.js';
 import { CAPABILITY_OUTPUTS } from '../../common.js';
@@ -22,6 +22,19 @@ export type AnimalCompanionBaseOutput = 'success' | 'error';
 class AnimalCompanionBaseNode extends ScalarNode<ScrapeState, AnimalCompanionBaseOutput> {
   public readonly name = 'extract:animal-companion-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<AnimalCompanionBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -49,6 +62,19 @@ class AnimalCompanionStatsNode extends ScalarNode<ScrapeState, AnimalCompanionSt
   public readonly name = 'extract:animal-companion-stats';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<AnimalCompanionStatsOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -73,6 +99,19 @@ export type AnimalCompanionCombatOutput = 'success' | 'error';
 class AnimalCompanionCombatNode extends ScalarNode<ScrapeState, AnimalCompanionCombatOutput> {
   public readonly name = 'extract:animal-companion-combat';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<AnimalCompanionCombatOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -99,6 +138,19 @@ class AnimalCompanionAdvancementNode extends ScalarNode<ScrapeState, AnimalCompa
   public readonly name = 'extract:animal-companion-advancement';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<AnimalCompanionAdvancementOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -123,6 +175,18 @@ export type FinalizeAnimalCompanionOutput = 'success';
 class FinalizeAnimalCompanionNode extends ScalarNode<ScrapeState, FinalizeAnimalCompanionOutput> {
   public readonly name = 'finalize:animal-companion';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeAnimalCompanionOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/archetype.ts
+++ b/plugins/aonprd/concepts/archetype.ts
@@ -8,7 +8,7 @@
 // dedication_feat_id) is individually accessible; the introduction slice
 // captures the rules_link cross-reference as a typed field.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 import type { Element } from 'domhandler';
 
@@ -446,6 +446,35 @@ class ArchetypeBaseNode extends ScalarNode<ScrapeState, ArchetypeBaseOutput> {
   public readonly name    = 'extract:archetype-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<ArchetypeBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              url:             { type: 'string' },
+              archetype_id:    { type: ['integer', 'null'] },
+              name:            { type: 'string' },
+              rarity:          { type: 'string' },
+              pfs:             { type: ['string', 'null'] },
+              legacy:          { type: 'boolean' },
+              alt_edition_url: { type: ['string', 'null'] },
+              traits:          { type: 'array', items: { type: 'string' } },
+              trait_ids:       { type: 'object' },
+              source:          { type: 'object' },
+              sources:         { type: 'array', items: { type: 'object' } },
+            },
+            required: ['url', 'name', 'rarity', 'traits', 'trait_ids', 'source', 'sources'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -473,6 +502,27 @@ export type ArchetypeIntroductionOutput = 'success' | 'error';
 class ArchetypeIntroductionNode extends ScalarNode<ScrapeState, ArchetypeIntroductionOutput> {
   public readonly name    = 'extract:archetype-introduction';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<ArchetypeIntroductionOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              introduction:      { type: 'string' },
+              introduction_html: { type: 'string' },
+              rules_link:        { type: ['object', 'null'] },
+            },
+            required: ['introduction', 'introduction_html'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -504,6 +554,27 @@ class ArchetypeFeatsNode extends ScalarNode<ScrapeState, ArchetypeFeatsOutput> {
   public readonly name    = 'extract:archetype-feats';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<ArchetypeFeatsOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              feats:              { type: 'array', items: { type: 'object' } },
+              feat_ids:           { type: 'array', items: { type: 'integer' } },
+              dedication_feat_id: { type: ['integer', 'null'] },
+            },
+            required: ['feats', 'feat_ids'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -533,6 +604,18 @@ export type FinalizeArchetypeOutput = 'success';
 class FinalizeArchetypeNode extends ScalarNode<ScrapeState, FinalizeArchetypeOutput> {
   public readonly name    = 'finalize:archetype';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeArchetypeOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/armor-group.ts
+++ b/plugins/aonprd/concepts/armor-group.ts
@@ -2,7 +2,7 @@
 // Armor-group pages have well-defined structure; the inlined helpers fully
 // cover the content shape.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -217,6 +217,35 @@ class ArmorGroupBaseNode extends ScalarNode<ScrapeState, ArmorGroupBaseOutput> {
   public readonly name = 'extract:armor-group-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<ArmorGroupBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              url:             { type: 'string' },
+              group_id:        { type: ['integer', 'null'] },
+              name:            { type: 'string' },
+              rarity:          { type: 'string' },
+              pfs:             { type: ['string', 'null'] },
+              legacy:          { type: 'boolean' },
+              alt_edition_url: { type: ['string', 'null'] },
+              traits:          { type: 'array', items: { type: 'string' } },
+              trait_ids:       { type: 'object' },
+              source:          { type: 'object' },
+              sources:         { type: 'array', items: { type: 'object' } },
+            },
+            required: ['url', 'name', 'rarity', 'traits', 'trait_ids', 'source', 'sources'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -241,6 +270,27 @@ export type ArmorGroupContentOutput = 'success' | 'error';
 class ArmorGroupContentNode extends ScalarNode<ScrapeState, ArmorGroupContentOutput> {
   public readonly name = 'extract:armor-group-content';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<ArmorGroupContentOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              armor_specialization_html: { type: 'string' },
+              armor_specialization_text: { type: 'string' },
+              armors: { type: 'array', items: { type: 'object' } },
+            },
+            required: ['armor_specialization_html', 'armor_specialization_text', 'armors'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -268,6 +318,19 @@ export type FinalizeArmorGroupOutput = 'success';
 class FinalizeArmorGroupNode extends ScalarNode<ScrapeState, FinalizeArmorGroupOutput> {
   public readonly name = 'finalize:armor-group';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeArmorGroupOutput, SchemaObjectType> {
+    return {
+      // `success` — merges sections, raw_fields, links, body_text, body_html, meta into state.output (no setConceptOutput call).
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/armor/concept.ts
+++ b/plugins/aonprd/concepts/armor/concept.ts
@@ -1,7 +1,7 @@
 // Armor concept declaration and capability nodes.
 
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
@@ -20,6 +20,19 @@ export type ArmorBaseOutput = 'success' | 'error';
 class ArmorBaseNode extends ScalarNode<ScrapeState, ArmorBaseOutput> {
   public readonly name    = 'extract:armor-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<ArmorBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -44,6 +57,19 @@ class ArmorMechanicsNode extends ScalarNode<ScrapeState, ArmorMechanicsOutput> {
   public readonly name    = 'extract:armor-mechanics';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<ArmorMechanicsOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -66,6 +92,18 @@ export type FinalizeArmorOutput = 'success';
 class FinalizeArmorNode extends ScalarNode<ScrapeState, FinalizeArmorOutput> {
   public readonly name    = 'finalize:armor';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeArmorOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/article.ts
+++ b/plugins/aonprd/concepts/article.ts
@@ -2,7 +2,7 @@
 // Article pages are prose-only entries; no structured improvements warranted
 // beyond legacy-section filtering.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -180,6 +180,36 @@ class ArticleBaseNodeImpl extends ScalarNode<ScrapeState, ArticleBaseOutput> {
   public readonly name    = 'extract:article-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<ArticleBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              url:             { type: 'string' },
+              article_id:      { type: ['integer', 'null'] },
+              name:            { type: 'string' },
+              rarity:          { type: 'string' },
+              pfs:             { type: ['string', 'null'] },
+              legacy:          { type: 'boolean' },
+              alt_edition_url: { type: ['string', 'null'] },
+              traits:          { type: 'array', items: { type: 'string' } },
+              trait_ids:       { type: 'object' },
+              source:          { type: 'object' },
+              sources:         { type: 'array', items: { type: 'object' } },
+              description:     { type: ['string', 'null'] },
+            },
+            required: ['url', 'name', 'rarity', 'traits', 'trait_ids', 'source', 'sources'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -206,6 +236,19 @@ export type FinalizeArticleOutput = 'success';
 class FinalizeArticleNodeImpl extends ScalarNode<ScrapeState, FinalizeArticleOutput> {
   public readonly name    = 'finalize:article';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeArticleOutput, SchemaObjectType> {
+    return {
+      // `success` — merges sections, raw_fields, links, body_text, body_html, meta into state.output (no setConceptOutput call).
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/background.ts
+++ b/plugins/aonprd/concepts/background.ts
@@ -5,7 +5,7 @@
 //
 // a single taxonomy node rather than an inline switch arm.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -235,6 +235,35 @@ class BackgroundBaseNode extends ScalarNode<ScrapeState, BackgroundBaseOutput> {
   public readonly name = 'extract:background-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<BackgroundBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              url:             { type: 'string' },
+              background_id:   { type: ['integer', 'null'] },
+              name:            { type: 'string' },
+              rarity:          { type: 'string' },
+              pfs:             { type: ['string', 'null'] },
+              legacy:          { type: 'boolean' },
+              alt_edition_url: { type: ['string', 'null'] },
+              traits:          { type: 'array', items: { type: 'string' } },
+              trait_ids:       { type: 'object' },
+              source:          { type: 'object' },
+              sources:         { type: 'array', items: { type: 'object' } },
+            },
+            required: ['url', 'name', 'rarity', 'traits', 'trait_ids', 'source', 'sources'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -265,6 +294,30 @@ class BackgroundBenefitsNode extends ScalarNode<ScrapeState, BackgroundBenefitsO
   public readonly name = 'extract:background-benefits';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<BackgroundBenefitsOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              attribute_boost_choice: { type: ['object', 'null'] },
+              trained_skills:         { type: 'array', items: { type: 'object' } },
+              lore_skills:            { type: 'array', items: { type: 'object' } },
+              granted_feat:           { type: ['object', 'null'] },
+              flavor_text:            { type: 'string' },
+              related_sources:        { type: 'array', items: { type: 'object' } },
+            },
+            required: ['trained_skills', 'lore_skills', 'flavor_text', 'related_sources'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -292,6 +345,18 @@ export type FinalizeBackgroundOutput = 'success';
 class FinalizeBackgroundNode extends ScalarNode<ScrapeState, FinalizeBackgroundOutput> {
   public readonly name = 'finalize:background';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeBackgroundOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/camp-activity.ts
+++ b/plugins/aonprd/concepts/camp-activity.ts
@@ -5,7 +5,7 @@
 //
 // bespoke node-folder under nodes/camp-activity/.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -188,6 +188,36 @@ class CampActivityBaseNode extends ScalarNode<ScrapeState, CampActivityBaseOutpu
   public readonly name = 'extract:camp-activity-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<CampActivityBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              url:             { type: 'string' },
+              activity_id:     { type: ['integer', 'null'] },
+              name:            { type: 'string' },
+              rarity:          { type: 'string' },
+              traits:          { type: 'array', items: { type: 'string' } },
+              trait_ids:       { type: 'object' },
+              action_cost:     { type: ['string', 'null'] },
+              source:          { type: 'object' },
+              sources:         { type: 'array', items: { type: 'object' } },
+              pfs:             { type: ['string', 'null'] },
+              legacy:          { type: 'boolean' },
+              alt_edition_url: { type: ['string', 'null'] },
+            },
+            required: ['url', 'name', 'rarity', 'traits', 'trait_ids', 'source', 'sources'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -213,6 +243,28 @@ class CampActivityMechanicsNode extends ScalarNode<ScrapeState, CampActivityMech
   public readonly name = 'extract:camp-activity-mechanics';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<CampActivityMechanicsOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              requirements: { type: ['string', 'null'] },
+              frequency:    { type: ['string', 'null'] },
+              description:  { type: 'string' },
+              outcomes:     { type: 'array', items: { type: 'object' } },
+            },
+            required: ['description', 'outcomes'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -237,6 +289,18 @@ export type FinalizeCampActivityOutput = 'success';
 class FinalizeCampActivityNode extends ScalarNode<ScrapeState, FinalizeCampActivityOutput> {
   public readonly name = 'finalize:camp-activity';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeCampActivityOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/camp-meal.ts
+++ b/plugins/aonprd/concepts/camp-meal.ts
@@ -5,7 +5,7 @@
 //
 // bespoke node-folder under nodes/camp-meal/.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -223,6 +223,36 @@ class CampMealBaseNodeImpl extends ScalarNode<ScrapeState, CampMealBaseOutput> {
   public readonly name    = 'extract:camp-meal-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<CampMealBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              url:             { type: 'string' },
+              meal_id:         { type: ['integer', 'null'] },
+              name:            { type: 'string' },
+              rarity:          { type: 'string' },
+              traits:          { type: 'array', items: { type: 'string' } },
+              trait_ids:       { type: 'object' },
+              level:           { type: ['integer', 'null'] },
+              source:          { type: 'object' },
+              sources:         { type: 'array', items: { type: 'object' } },
+              pfs:             { type: ['string', 'null'] },
+              legacy:          { type: 'boolean' },
+              alt_edition_url: { type: ['string', 'null'] },
+            },
+            required: ['url', 'name', 'rarity', 'traits', 'trait_ids', 'source', 'sources'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -247,6 +277,30 @@ class CampMealMechanicsNodeImpl extends ScalarNode<ScrapeState, CampMealMechanic
   public readonly name    = 'extract:camp-meal-mechanics';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<CampMealMechanicsOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              recipe_price:  { type: ['string', 'null'] },
+              ingredients:   { type: ['string', 'null'] },
+              preparation:   { type: ['string', 'null'] },
+              favorite_meal: { type: ['string', 'null'] },
+              description:   { type: 'string' },
+              outcomes:      { type: 'array', items: { type: 'object' } },
+            },
+            required: ['description', 'outcomes'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -270,6 +324,18 @@ export type FinalizeCampMealOutput = 'success';
 class FinalizeCampMealNodeImpl extends ScalarNode<ScrapeState, FinalizeCampMealOutput> {
   public readonly name    = 'finalize:camp-meal';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeCampMealOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/class-kit.ts
+++ b/plugins/aonprd/concepts/class-kit.ts
@@ -6,7 +6,7 @@
 // equipment-list slices for downstream consumers without re-running the full
 // pipeline.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -283,6 +283,35 @@ class ClassKitBaseNodeImpl extends ScalarNode<ScrapeState, ClassKitBaseOutput> {
   public readonly name = 'extract:class-kit-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<ClassKitBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              url:             { type: 'string' },
+              class_kit_id:    { type: ['integer', 'null'] },
+              name:            { type: 'string' },
+              rarity:          { type: 'string' },
+              pfs:             { type: ['string', 'null'] },
+              legacy:          { type: 'boolean' },
+              alt_edition_url: { type: ['string', 'null'] },
+              traits:          { type: 'array', items: { type: 'string' } },
+              trait_ids:       { type: 'object' },
+              source:          { type: 'object' },
+              sources:         { type: 'array', items: { type: 'object' } },
+            },
+            required: ['url', 'name', 'rarity', 'traits', 'trait_ids', 'source', 'sources'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -310,6 +339,31 @@ class ClassKitContentsNodeImpl extends ScalarNode<ScrapeState, ClassKitContentsO
   public readonly name = 'extract:class-kit-contents';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<ClassKitContentsOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              price:           { type: ['string', 'null'] },
+              bulk:            { type: ['string', 'null'] },
+              money_left_over: { type: ['string', 'null'] },
+              armor:           { type: 'array', items: { type: 'object' } },
+              weapons:         { type: 'array', items: { type: 'object' } },
+              gear:            { type: 'array', items: { type: 'object' } },
+              options:         { type: 'array', items: { type: 'object' } },
+            },
+            required: ['armor', 'weapons', 'gear', 'options'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -336,6 +390,18 @@ export type FinalizeClassKitOutput = 'success';
 class FinalizeClassKitNodeImpl extends ScalarNode<ScrapeState, FinalizeClassKitOutput> {
   public readonly name = 'finalize:class-kit';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeClassKitOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/class-sample.ts
+++ b/plugins/aonprd/concepts/class-sample.ts
@@ -5,7 +5,7 @@
 //
 // captures any unclassified h2 sections so no data is silently dropped.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -391,6 +391,35 @@ class ClassSampleBaseNode extends ScalarNode<ScrapeState, ClassSampleBaseOutput>
   public readonly name = 'extract:class-sample-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<ClassSampleBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              url:             { type: 'string' },
+              class_sample_id: { type: ['integer', 'null'] },
+              name:            { type: 'string' },
+              rarity:          { type: 'string' },
+              pfs:             { type: ['string', 'null'] },
+              legacy:          { type: 'boolean' },
+              alt_edition_url: { type: ['string', 'null'] },
+              traits:          { type: 'array', items: { type: 'string' } },
+              trait_ids:       { type: 'object' },
+              source:          { type: 'object' },
+              sources:         { type: 'array', items: { type: 'object' } },
+            },
+            required: ['url', 'name', 'rarity', 'traits', 'trait_ids', 'source', 'sources'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -418,6 +447,24 @@ export type ClassSampleIdentityOutput = 'success' | 'error';
 class ClassSampleIdentityNode extends ScalarNode<ScrapeState, ClassSampleIdentityOutput> {
   public readonly name = 'extract:class-sample-identity';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<ClassSampleIdentityOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              flavor: { type: ['string', 'null'] },
+            },
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -447,6 +494,31 @@ class ClassSampleBuildNode extends ScalarNode<ScrapeState, ClassSampleBuildOutpu
   public readonly name = 'extract:class-sample-build';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<ClassSampleBuildOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              ability_scores:     { type: ['string', 'null'] },
+              skills:             { type: 'array', items: { type: 'object' } },
+              research_field:     { type: ['object', 'null'] },
+              starting_feat:      { type: ['object', 'null'] },
+              higher_level_feats: { type: 'array', items: { type: 'object' } },
+              implements:         { type: 'array', items: { type: 'object' } },
+              extra_sections:     { type: 'array', items: { type: 'object' } },
+            },
+            required: ['skills', 'higher_level_feats', 'implements', 'extra_sections'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -474,6 +546,18 @@ export type FinalizeClassSampleOutput = 'success';
 class FinalizeClassSampleNode extends ScalarNode<ScrapeState, FinalizeClassSampleOutput> {
   public readonly name = 'finalize:class-sample';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeClassSampleOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/class/concept.ts
+++ b/plugins/aonprd/concepts/class/concept.ts
@@ -1,6 +1,6 @@
 
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
@@ -23,6 +23,19 @@ export type ClassBaseOutput = 'success' | 'error';
 class ClassBaseNode extends ScalarNode<ScrapeState, ClassBaseOutput> {
   public readonly name = 'extract:class-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<ClassBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -53,6 +66,19 @@ class ClassProgressionNode extends ScalarNode<ScrapeState, ClassProgressionOutpu
   public readonly name = 'extract:class-progression';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<ClassProgressionOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -80,6 +106,19 @@ class ClassSubclassesNode extends ScalarNode<ScrapeState, ClassSubclassesOutput>
   public readonly name = 'extract:class-subclasses';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<ClassSubclassesOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -106,6 +145,18 @@ export type FinalizeClassOutput = 'success';
 class FinalizeClassNode extends ScalarNode<ScrapeState, FinalizeClassOutput> {
   public readonly name = 'finalize:class';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeClassOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/condition/concept.ts
+++ b/plugins/aonprd/concepts/condition/concept.ts
@@ -1,5 +1,5 @@
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
@@ -20,6 +20,19 @@ export type ConditionBaseOutput = 'success' | 'error';
 class ConditionBaseNode extends ScalarNode<ScrapeState, ConditionBaseOutput> {
   public readonly name = 'extract:condition-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<ConditionBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -46,6 +59,18 @@ export type FinalizeConditionOutput = 'success';
 class FinalizeConditionNode extends ScalarNode<ScrapeState, FinalizeConditionOutput> {
   public readonly name = 'finalize:condition';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeConditionOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/contributor.ts
+++ b/plugins/aonprd/concepts/contributor.ts
@@ -2,7 +2,7 @@
 // Contributor pages have minimal structured data; no improvements warranted
 // beyond legacy-section filtering.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -266,6 +266,35 @@ class ContributorBaseNode extends ScalarNode<ScrapeState, ContributorBaseOutput>
   public readonly name = 'extract:contributor-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<ContributorBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              url:             { type: 'string' },
+              contributor_id:  { type: ['integer', 'null'] },
+              name:            { type: 'string' },
+              rarity:          { type: 'string' },
+              pfs:             { type: ['string', 'null'] },
+              legacy:          { type: 'boolean' },
+              alt_edition_url: { type: ['string', 'null'] },
+              traits:          { type: 'array', items: { type: 'string' } },
+              trait_ids:       { type: 'object' },
+              source:          { type: 'object' },
+              sources:         { type: 'array', items: { type: 'object' } },
+            },
+            required: ['url', 'name', 'rarity', 'traits', 'trait_ids', 'source', 'sources'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -290,6 +319,30 @@ export type ContributorProfileOutput = 'success' | 'error';
 class ContributorProfileNode extends ScalarNode<ScrapeState, ContributorProfileOutput> {
   public readonly name = 'extract:contributor-profile';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<ContributorProfileOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              title:    { type: ['string', 'null'] },
+              email:    { type: ['string', 'null'] },
+              location: { type: ['string', 'null'] },
+              website:  { type: ['string', 'null'] },
+              bio_html: { type: 'string' },
+              bio_text: { type: 'string' },
+            },
+            required: ['bio_html', 'bio_text'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -317,6 +370,19 @@ export type FinalizeContributorOutput = 'success';
 class FinalizeContributorNode extends ScalarNode<ScrapeState, FinalizeContributorOutput> {
   public readonly name = 'finalize:contributor';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeContributorOutput, SchemaObjectType> {
+    return {
+      // `success` — merges sections, raw_fields, links, body_text, body_html, meta into state.output (no setConceptOutput call).
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/curse.ts
+++ b/plugins/aonprd/concepts/curse.ts
@@ -4,7 +4,7 @@
 // Helpers are inlined with inline contracts. The `entity_id` alias was
 // dropped in favour of the concept-specific `curse_id`.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -318,6 +318,36 @@ class CurseBaseNodeImpl extends ScalarNode<ScrapeState, CurseBaseOutput> {
   public readonly name    = 'extract:curse-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<CurseBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              url:             { type: 'string' },
+              curse_id:        { type: ['integer', 'null'] },
+              name:            { type: 'string' },
+              level:           { type: ['integer', 'null'] },
+              rarity:          { type: 'string' },
+              pfs:             { type: ['string', 'null'] },
+              legacy:          { type: 'boolean' },
+              alt_edition_url: { type: ['string', 'null'] },
+              traits:          { type: 'array', items: { type: 'string' } },
+              trait_ids:       { type: 'object' },
+              source:          { type: 'object' },
+              sources:         { type: 'array', items: { type: 'object' } },
+            },
+            required: ['url', 'name', 'rarity', 'traits', 'trait_ids', 'source', 'sources'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -341,6 +371,26 @@ export type CurseMechanicsOutput = 'success' | 'error';
 class CurseMechanicsNodeImpl extends ScalarNode<ScrapeState, CurseMechanicsOutput> {
   public readonly name    = 'extract:curse-mechanics';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<CurseMechanicsOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              saving_throw:     { type: ['object', 'null'] },
+              onset:            { type: ['string', 'null'] },
+              maximum_duration: { type: ['string', 'null'] },
+            },
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -366,6 +416,37 @@ class CurseStagesNodeImpl extends ScalarNode<ScrapeState, CurseStagesOutput> {
   public readonly name    = 'extract:curse-stages';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<CurseStagesOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              stages: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    stage:     { type: 'integer' },
+                    body_text: { type: 'string' },
+                    body_html: { type: 'string' },
+                    duration:  { type: ['string', 'null'] },
+                  },
+                  required: ['stage', 'body_text', 'body_html'],
+                },
+              },
+            },
+            required: ['stages'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -389,6 +470,18 @@ export type FinalizeCurseOutput = 'success';
 class FinalizeCurseNodeImpl extends ScalarNode<ScrapeState, FinalizeCurseOutput> {
   public readonly name    = 'finalize:curse';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeCurseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/deity-category.ts
+++ b/plugins/aonprd/concepts/deity-category.ts
@@ -9,7 +9,7 @@
 //   extract:deity-category-aspects  — descriptive prose before the Members heading
 //   finalize:deity-category         — assemble + strip raw_fields, attach meta
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -261,6 +261,35 @@ class DeityCategoryBaseNodeImpl extends ScalarNode<ScrapeState, DeityCategoryBas
   public readonly name = 'extract:deity-category-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<DeityCategoryBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              url:               { type: 'string' },
+              deity_category_id: { type: ['integer', 'null'] },
+              name:              { type: 'string' },
+              rarity:            { type: 'string' },
+              pfs:               { type: ['string', 'null'] },
+              legacy:            { type: 'boolean' },
+              alt_edition_url:   { type: ['string', 'null'] },
+              traits:            { type: 'array', items: { type: 'string' } },
+              trait_ids:         { type: 'object' },
+              source:            { type: 'object' },
+              sources:           { type: 'array', items: { type: 'object' } },
+            },
+            required: ['url', 'name', 'rarity', 'traits', 'trait_ids', 'source', 'sources'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -288,6 +317,36 @@ export type DeityCategoryMembersOutput = 'success' | 'error';
 class DeityCategoryMembersNodeImpl extends ScalarNode<ScrapeState, DeityCategoryMembersOutput> {
   public readonly name = 'extract:deity-category-members';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<DeityCategoryMembersOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              members: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    name:     { type: 'string' },
+                    deity_id: { type: ['integer', 'null'] },
+                    href:     { type: 'string' },
+                  },
+                  required: ['name', 'href'],
+                },
+              },
+            },
+            required: ['members'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -318,6 +377,25 @@ class DeityCategoryAspectsNodeImpl extends ScalarNode<ScrapeState, DeityCategory
   public readonly name = 'extract:deity-category-aspects';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<DeityCategoryAspectsOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              aspects: { type: ['string', 'null'] },
+            },
+            required: ['aspects'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -345,6 +423,18 @@ export type FinalizeDeityCategoryOutput = 'success';
 class FinalizeDeityCategoryNodeImpl extends ScalarNode<ScrapeState, FinalizeDeityCategoryOutput> {
   public readonly name = 'finalize:deity-category';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeDeityCategoryOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/deity/concept.ts
+++ b/plugins/aonprd/concepts/deity/concept.ts
@@ -13,7 +13,7 @@
 //   finalize:deity                 — assemble + strip raw_fields, attach meta
 
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
@@ -39,6 +39,19 @@ export type DeityBaseOutput = 'success' | 'error';
 class DeityBaseNodeImpl extends ScalarNode<ScrapeState, DeityBaseOutput> {
   public readonly name = 'extract:deity-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<DeityBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -68,6 +81,19 @@ class DeityDevoteeBenefitsNodeImpl extends ScalarNode<ScrapeState, DeityDevoteeB
   public readonly name = 'extract:deity-devotee-benefits';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<DeityDevoteeBenefitsOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -96,6 +122,19 @@ class DeityEdictsAnathemaNodeImpl extends ScalarNode<ScrapeState, DeityEdictsAna
   public readonly name = 'extract:deity-edicts-anathema';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<DeityEdictsAnathemaOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -122,6 +161,19 @@ export type DeityClericSpellsOutput = 'success' | 'error';
 class DeityClericSpellsNodeImpl extends ScalarNode<ScrapeState, DeityClericSpellsOutput> {
   public readonly name = 'extract:deity-cleric-spells';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<DeityClericSpellsOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -150,6 +202,19 @@ class DeityRelationshipsNodeImpl extends ScalarNode<ScrapeState, DeityRelationsh
   public readonly name = 'extract:deity-relationships';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<DeityRelationshipsOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -177,6 +242,18 @@ export type FinalizeDeityOutput = 'success';
 class FinalizeDeityNodeImpl extends ScalarNode<ScrapeState, FinalizeDeityOutput> {
   public readonly name = 'finalize:deity';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeDeityOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/disease.ts
+++ b/plugins/aonprd/concepts/disease.ts
@@ -4,7 +4,7 @@
 // Helpers are inlined with inline contracts. The `entity_id` alias was
 // dropped in favour of the concept-specific `disease_id`.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -301,6 +301,36 @@ class DiseaseBaseNode extends ScalarNode<ScrapeState, DiseaseBaseOutput> {
   public readonly name = 'extract:disease-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<DiseaseBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              url:             { type: 'string' },
+              disease_id:      { type: ['integer', 'null'] },
+              name:            { type: 'string' },
+              level:           { type: ['integer', 'null'] },
+              rarity:          { type: 'string' },
+              pfs:             { type: ['string', 'null'] },
+              legacy:          { type: 'boolean' },
+              alt_edition_url: { type: ['string', 'null'] },
+              traits:          { type: 'array', items: { type: 'string' } },
+              trait_ids:       { type: 'object' },
+              source:          { type: 'object' },
+              sources:         { type: 'array', items: { type: 'object' } },
+            },
+            required: ['url', 'name', 'rarity', 'traits', 'trait_ids', 'source', 'sources'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -325,6 +355,26 @@ export type DiseaseMechanicsOutput = 'success' | 'error';
 class DiseaseMechanicsNode extends ScalarNode<ScrapeState, DiseaseMechanicsOutput> {
   public readonly name = 'extract:disease-mechanics';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<DiseaseMechanicsOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              saving_throw:     { type: ['object', 'null'] },
+              onset:            { type: ['string', 'null'] },
+              maximum_duration: { type: ['string', 'null'] },
+            },
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -351,6 +401,37 @@ class DiseaseStagesNode extends ScalarNode<ScrapeState, DiseaseStagesOutput> {
   public readonly name = 'extract:disease-stages';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<DiseaseStagesOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              stages: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    stage:     { type: 'integer' },
+                    body_text: { type: 'string' },
+                    body_html: { type: 'string' },
+                    duration:  { type: ['string', 'null'] },
+                  },
+                  required: ['stage', 'body_text', 'body_html'],
+                },
+              },
+            },
+            required: ['stages'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -375,6 +456,18 @@ export type FinalizeDiseaseOutput = 'success';
 class FinalizeDiseaseNode extends ScalarNode<ScrapeState, FinalizeDiseaseOutput> {
   public readonly name = 'finalize:disease';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeDiseaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/domain.ts
+++ b/plugins/aonprd/concepts/domain.ts
@@ -4,7 +4,7 @@
 // Spells subsection, and a brief flavor description. This concept delegates to
 // Helpers are inlined with inline contracts.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -489,6 +489,35 @@ class DomainBaseNode extends ScalarNode<ScrapeState, DomainBaseOutput> {
   public readonly name    = 'extract:domain-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<DomainBaseOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              url:             { type: 'string' },
+              domain_id:       { type: ['integer', 'null'] },
+              name:            { type: 'string' },
+              rarity:          { type: 'string' },
+              traits:          { type: 'array', items: { type: 'string' } },
+              trait_ids:       { type: 'object' },
+              source:          { type: 'object' },
+              sources:         { type: 'array', items: { type: 'object' } },
+              legacy:          { type: 'boolean' },
+              alt_edition_url: { type: ['string', 'null'] },
+              pfs:             { type: ['string', 'null'] },
+            },
+            required: ['url', 'name', 'rarity', 'traits', 'trait_ids', 'source', 'sources'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -513,6 +542,26 @@ export type DomainSpellsOutput = 'success' | 'error';
 class DomainSpellsNode extends ScalarNode<ScrapeState, DomainSpellsOutput> {
   public readonly name    = 'extract:domain-spells';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<DomainSpellsOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              domain_spell:          { type: ['object', 'null'] },
+              advanced_domain_spell: { type: ['object', 'null'] },
+              apocryphal:            { type: ['object', 'null'] },
+            },
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -539,6 +588,28 @@ class DomainMetaNode extends ScalarNode<ScrapeState, DomainMetaOutput> {
   public readonly name    = 'extract:domain-meta';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<DomainMetaOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              description_text: { type: 'string' },
+              description_html: { type: 'string' },
+              sections:         { type: 'array', items: { type: 'object' } },
+              deities_using:    { type: 'array', items: { type: 'object' } },
+            },
+            required: ['description_text', 'description_html', 'sections', 'deities_using'],
+          },
+        },
+        required: ['output'],
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -563,6 +634,18 @@ export type FinalizeDomainOutput = 'success';
 class FinalizeDomainNode extends ScalarNode<ScrapeState, FinalizeDomainOutput> {
   public readonly name    = 'finalize:domain';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeDomainOutput, SchemaObjectType> {
+    return {
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/equipment/finalize.ts
+++ b/plugins/aonprd/concepts/equipment/finalize.ts
@@ -7,7 +7,7 @@
  * EquipmentBaseOutput, EquipmentMechanicsOutput, FinalizeEquipmentOutput.
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
@@ -173,6 +173,13 @@ class EquipmentBaseNode extends ScalarNode<ScrapeState, EquipmentBaseOutput> {
   public readonly name    = 'extract:equipment-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<EquipmentBaseOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
   ): Promise<NodeOutputType<EquipmentBaseOutput>> {
@@ -195,6 +202,13 @@ class EquipmentMechanicsNode extends ScalarNode<ScrapeState, EquipmentMechanicsO
   public readonly name    = 'extract:equipment-mechanics';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<EquipmentMechanicsOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
   ): Promise<NodeOutputType<EquipmentMechanicsOutput>> {
@@ -216,6 +230,12 @@ export type FinalizeEquipmentOutput = 'success';
 class FinalizeEquipmentNode extends ScalarNode<ScrapeState, FinalizeEquipmentOutput> {
   public readonly name    = 'finalize:equipment';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeEquipmentOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/familiar/nodes.ts
+++ b/plugins/aonprd/concepts/familiar/nodes.ts
@@ -1,6 +1,6 @@
 // Familiar capability nodes.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 import type { ScrapeState } from '../../../../src/state/ScrapeState.js';
 import { CAPABILITY_OUTPUTS } from '../../common.js';
@@ -22,6 +22,14 @@ export type FamiliarBaseOutput = 'success' | 'error';
 class FamiliarBaseNode extends ScalarNode<ScrapeState, FamiliarBaseOutput> {
   public readonly name = 'extract:familiar-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<FamiliarBaseOutput, SchemaObjectType> {
+    return {
+      // state.output merged with FamiliarBaseSlice fields
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -48,6 +56,14 @@ class FamiliarPrerequisitesNode extends ScalarNode<ScrapeState, FamiliarPrerequi
   public readonly name = 'extract:familiar-prerequisites';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<FamiliarPrerequisitesOutput, SchemaObjectType> {
+    return {
+      // state.output merged with FamiliarPrerequisitesSlice fields
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -72,6 +88,13 @@ export type FinalizeFamiliarOutput = 'success';
 class FinalizeFamiliarNode extends ScalarNode<ScrapeState, FinalizeFamiliarOutput> {
   public readonly name = 'finalize:familiar';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeFamiliarOutput, SchemaObjectType> {
+    return {
+      // setConceptOutput writes fully assembled FamiliarOutput to state.output
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/feat.ts
+++ b/plugins/aonprd/concepts/feat.ts
@@ -9,7 +9,7 @@
 // re-execution in the taxonomy pipeline; myth-feat disambiguation is
 // transparent via the `is_mythic` field rather than a separate type.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -462,6 +462,14 @@ class FeatBaseNode extends ScalarNode<ScrapeState, FeatBaseOutput> {
   public readonly name    = 'extract:feat-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<FeatBaseOutput, SchemaObjectType> {
+    return {
+      // state.output merged with FeatBaseSlice (url, feat_id, name, level, rarity, pfs, traits, source, is_mythic, meta_*)
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -491,6 +499,14 @@ export type FeatPrerequisitesOutput = 'success' | 'error';
 class FeatPrerequisitesNode extends ScalarNode<ScrapeState, FeatPrerequisitesOutput> {
   public readonly name    = 'extract:feat-prerequisites';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<FeatPrerequisitesOutput, SchemaObjectType> {
+    return {
+      // state.output merged with FeatPrerequisitesSlice (archetypes, archetype_footnotes, class_archetypes, spoiler_source, prerequisites)
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -522,6 +538,14 @@ class FeatEffectNode extends ScalarNode<ScrapeState, FeatEffectOutput> {
   public readonly name    = 'extract:feat-effect';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<FeatEffectOutput, SchemaObjectType> {
+    return {
+      // state.output merged with FeatEffectSlice (frequency, trigger, requirements, cost, access, description_html, description_text, special)
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -549,6 +573,14 @@ export type FeatMetaOutput = 'success' | 'error';
 class FeatMetaNode extends ScalarNode<ScrapeState, FeatMetaOutput> {
   public readonly name    = 'extract:feat-meta';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<FeatMetaOutput, SchemaObjectType> {
+    return {
+      // state.output merged with FeatMetaSlice (leads_to, related_feats, trait_glossary, links)
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -579,6 +611,13 @@ export type FinalizeFeatOutput = 'success';
 class FinalizeFeatNode extends ScalarNode<ScrapeState, FinalizeFeatOutput> {
   public readonly name    = 'finalize:feat';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeFeatOutput, SchemaObjectType> {
+    return {
+      // setConceptOutput writes fully assembled FeatOutput to state.output
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/generic/concept.ts
+++ b/plugins/aonprd/concepts/generic/concept.ts
@@ -3,7 +3,7 @@
 // helpers in contract-carrying capability nodes.
 
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
@@ -21,6 +21,14 @@ export type GenericExtractOutput = 'success' | 'error';
 class GenericExtractNode extends ScalarNode<ScrapeState, GenericExtractOutput> {
   public readonly name    = 'extract:generic';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<GenericExtractOutput, SchemaObjectType> {
+    return {
+      // setConceptOutput writes the extracted GenericOutput to state.output
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/hazard/concept.ts
+++ b/plugins/aonprd/concepts/hazard/concept.ts
@@ -1,5 +1,5 @@
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
@@ -22,6 +22,14 @@ export type HazardBaseOutput = 'success' | 'error';
 class HazardBaseNode extends ScalarNode<ScrapeState, HazardBaseOutput> {
   public readonly name = 'extract:hazard-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<HazardBaseOutput, SchemaObjectType> {
+    return {
+      // state.output merged with HazardBaseSlice fields
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -46,6 +54,14 @@ class HazardDefensesNode extends ScalarNode<ScrapeState, HazardDefensesOutput> {
   public readonly name = 'extract:hazard-defenses';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<HazardDefensesOutput, SchemaObjectType> {
+    return {
+      // state.output merged with HazardDefensesSlice fields
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -68,6 +84,13 @@ export type FinalizeHazardOutput = 'success';
 class FinalizeHazardNode extends ScalarNode<ScrapeState, FinalizeHazardOutput> {
   public readonly name = 'finalize:hazard';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeHazardOutput, SchemaObjectType> {
+    return {
+      // setConceptOutput writes fully assembled HazardOutput to state.output
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/km-event.ts
+++ b/plugins/aonprd/concepts/km-event.ts
@@ -5,7 +5,7 @@
 //
 // bespoke node-folder under nodes/km-event/.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -263,6 +263,12 @@ export type KmEventBaseOutput = 'success' | 'error';
 class KmEventBaseNodeImpl extends ScalarNode<ScrapeState, KmEventBaseOutput> {
   public readonly name    = 'extract:km-event-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+  public override get outputSchema(): Record<KmEventBaseOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -287,6 +293,12 @@ export type KmEventMechanicsOutput = 'success' | 'error';
 class KmEventMechanicsNodeImpl extends ScalarNode<ScrapeState, KmEventMechanicsOutput> {
   public readonly name    = 'extract:km-event-mechanics';
   public readonly outputs = CAPABILITY_OUTPUTS;
+  public override get outputSchema(): Record<KmEventMechanicsOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -311,6 +323,11 @@ export type FinalizeKmEventOutput = 'success';
 class FinalizeKmEventNodeImpl extends ScalarNode<ScrapeState, FinalizeKmEventOutput> {
   public readonly name    = 'finalize:km-event';
   public readonly outputs = ['success'] as const;
+  public override get outputSchema(): Record<FinalizeKmEventOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/km-structure.ts
+++ b/plugins/aonprd/concepts/km-structure.ts
@@ -5,7 +5,7 @@
 //
 // bespoke node-folder under nodes/km-structure/.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -345,6 +345,12 @@ export type KmStructureBaseOutput = 'success' | 'error';
 class KmStructureBaseNodeImpl extends ScalarNode<ScrapeState, KmStructureBaseOutput> {
   public readonly name = 'extract:km-structure-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+  public override get outputSchema(): Record<KmStructureBaseOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -369,6 +375,12 @@ export type KmStructureMechanicsOutput = 'success' | 'error';
 class KmStructureMechanicsNodeImpl extends ScalarNode<ScrapeState, KmStructureMechanicsOutput> {
   public readonly name = 'extract:km-structure-mechanics';
   public readonly outputs = CAPABILITY_OUTPUTS;
+  public override get outputSchema(): Record<KmStructureMechanicsOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -393,6 +405,11 @@ export type FinalizeKmStructureOutput = 'success';
 class FinalizeKmStructureNodeImpl extends ScalarNode<ScrapeState, FinalizeKmStructureOutput> {
   public readonly name = 'finalize:km-structure';
   public readonly outputs = ['success'] as const;
+  public override get outputSchema(): Record<FinalizeKmStructureOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/km-war-army.ts
+++ b/plugins/aonprd/concepts/km-war-army.ts
@@ -6,7 +6,7 @@
 //
 // bespoke node-folder under nodes/km-war-army/.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -341,6 +341,12 @@ export type KmWarArmyBaseOutput = 'success' | 'error';
 class KmWarArmyBaseNode extends ScalarNode<ScrapeState, KmWarArmyBaseOutput> {
   public readonly name = 'extract:km-war-army-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+  public override get outputSchema(): Record<KmWarArmyBaseOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -366,6 +372,12 @@ export type KmWarArmyStatblockOutput = 'success' | 'error';
 class KmWarArmyStatblockNode extends ScalarNode<ScrapeState, KmWarArmyStatblockOutput> {
   public readonly name = 'extract:km-war-army-statblock';
   public readonly outputs = CAPABILITY_OUTPUTS;
+  public override get outputSchema(): Record<KmWarArmyStatblockOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -391,6 +403,12 @@ export type KmWarArmyAbilitiesOutput = 'success' | 'error';
 class KmWarArmyAbilitiesNode extends ScalarNode<ScrapeState, KmWarArmyAbilitiesOutput> {
   public readonly name = 'extract:km-war-army-abilities';
   public readonly outputs = CAPABILITY_OUTPUTS;
+  public override get outputSchema(): Record<KmWarArmyAbilitiesOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -416,6 +434,11 @@ export type FinalizeKmWarArmyOutput = 'success';
 class FinalizeKmWarArmyNode extends ScalarNode<ScrapeState, FinalizeKmWarArmyOutput> {
   public readonly name = 'finalize:km-war-army';
   public readonly outputs = ['success'] as const;
+  public override get outputSchema(): Record<FinalizeKmWarArmyOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/km-war-tactic.ts
+++ b/plugins/aonprd/concepts/km-war-tactic.ts
@@ -6,7 +6,7 @@
 //
 // bespoke node-folder under nodes/km-war-tactic/.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -195,6 +195,12 @@ export type KmWarTacticBaseOutput = 'success' | 'error';
 class KmWarTacticBaseNode extends ScalarNode<ScrapeState, KmWarTacticBaseOutput> {
   public readonly name = 'extract:km-war-tactic-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+  public override get outputSchema(): Record<KmWarTacticBaseOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -220,6 +226,12 @@ export type KmWarTacticMechanicsOutput = 'success' | 'error';
 class KmWarTacticMechanicsNode extends ScalarNode<ScrapeState, KmWarTacticMechanicsOutput> {
   public readonly name = 'extract:km-war-tactic-mechanics';
   public readonly outputs = CAPABILITY_OUTPUTS;
+  public override get outputSchema(): Record<KmWarTacticMechanicsOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -245,6 +257,11 @@ export type FinalizeKmWarTacticOutput = 'success';
 class FinalizeKmWarTacticNode extends ScalarNode<ScrapeState, FinalizeKmWarTacticOutput> {
   public readonly name = 'finalize:km-war-tactic';
   public readonly outputs = ['success'] as const;
+  public override get outputSchema(): Record<FinalizeKmWarTacticOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/language.ts
+++ b/plugins/aonprd/concepts/language.ts
@@ -8,7 +8,7 @@
 //   - `pfs_note` is NEW.
 //   - `sections[]` filters out legacy-content-warning headings.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -301,6 +301,14 @@ class LanguageBaseNode extends ScalarNode<ScrapeState, LanguageBaseOutput> {
   public readonly name = 'extract:language-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<LanguageBaseOutput, SchemaObjectType> {
+    return {
+      // state.output merged with language base fields (url, language_id, name, rarity, pfs, traits, source, kind, script)
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -346,6 +354,21 @@ export type LanguageSpeakersOutput = 'success' | 'error';
 class LanguageSpeakersNode extends ScalarNode<ScrapeState, LanguageSpeakersOutput> {
   public readonly name = 'extract:language-speakers';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<LanguageSpeakersOutput, SchemaObjectType> {
+    return {
+      // state.output gets speakers (object with ancestries/creatures/npcs/monsters/etc arrays) and section_counts (object)
+      success: {
+        type: 'object',
+        properties: {
+          speakers:       { type: 'object' },
+          section_counts: { type: 'object' },
+        },
+        required: ['speakers', 'section_counts'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -401,6 +424,19 @@ class LanguagePfsNoteNode extends ScalarNode<ScrapeState, LanguagePfsNoteOutput>
   public readonly name = 'extract:language-pfs-note';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<LanguagePfsNoteOutput, SchemaObjectType> {
+    return {
+      // state.output gets pfs_note: string | null
+      success: {
+        type: 'object',
+        properties: {
+          pfs_note: { type: 'string' },
+        },
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -433,6 +469,22 @@ export type LanguageDescriptionOutput = 'success' | 'error';
 class LanguageDescriptionNode extends ScalarNode<ScrapeState, LanguageDescriptionOutput> {
   public readonly name = 'extract:language-description';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<LanguageDescriptionOutput, SchemaObjectType> {
+    return {
+      // state.output gets description_text (string), description_html (string), sections (array)
+      success: {
+        type: 'object',
+        properties: {
+          description_text: { type: 'string' },
+          description_html: { type: 'string' },
+          sections:         { type: 'array', items: { type: 'object' } },
+        },
+        required: ['description_text', 'description_html', 'sections'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -476,6 +528,13 @@ export type FinalizeLanguageOutput = 'success';
 class FinalizeLanguageNode extends ScalarNode<ScrapeState, FinalizeLanguageOutput> {
   public readonly name = 'finalize:language';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeLanguageOutput, SchemaObjectType> {
+    return {
+      // setConceptOutput writes fully assembled LanguageOutput to state.output
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/monster-ability.ts
+++ b/plugins/aonprd/concepts/monster-ability.ts
@@ -3,7 +3,7 @@
 // Frequency / Effect labels plus prose). Adds cross-reference harvest for
 // related MonsterAbilities.aspx links.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -254,6 +254,13 @@ class MonsterAbilityBaseNode extends ScalarNode<ScrapeState, MonsterAbilityBaseO
   public readonly name    = 'extract:monster-ability-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<MonsterAbilityBaseOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -279,6 +286,13 @@ class MonsterAbilityDefinitionNode extends ScalarNode<ScrapeState, MonsterAbilit
   public readonly name    = 'extract:monster-ability-definition';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<MonsterAbilityDefinitionOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -303,6 +317,12 @@ export type FinalizeMonsterAbilityOutput = 'success';
 class FinalizeMonsterAbilityNode extends ScalarNode<ScrapeState, FinalizeMonsterAbilityOutput> {
   public readonly name    = 'finalize:monster-ability';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeMonsterAbilityOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/monster-family.ts
+++ b/plugins/aonprd/concepts/monster-family.ts
@@ -3,7 +3,7 @@
 // data; the inlined helpers handle the Members framing section harvest and
 // family identity.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -207,6 +207,13 @@ class MonsterFamilyBaseNode extends ScalarNode<ScrapeState, MonsterFamilyBaseOut
   public readonly name = 'extract:monster-family-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<MonsterFamilyBaseOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -232,6 +239,13 @@ class MonsterFamilyMembersNode extends ScalarNode<ScrapeState, MonsterFamilyMemb
   public readonly name = 'extract:monster-family-members';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<MonsterFamilyMembersOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -256,6 +270,12 @@ export type FinalizeMonsterFamilyOutput = 'success';
 class FinalizeMonsterFamilyNode extends ScalarNode<ScrapeState, FinalizeMonsterFamilyOutput> {
   public readonly name = 'finalize:monster-family';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeMonsterFamilyOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/monster-template.ts
+++ b/plugins/aonprd/concepts/monster-template.ts
@@ -3,7 +3,7 @@
 // Undead, etc.) with bullet adjustments, optional subsections, HP tables, and
 // best-effort numeric delta parsing.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -344,6 +344,13 @@ class MonsterTemplateBaseNode extends ScalarNode<ScrapeState, MonsterTemplateBas
   public readonly name = 'extract:monster-template-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<MonsterTemplateBaseOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -369,6 +376,13 @@ class MonsterTemplateModificationsNode extends ScalarNode<ScrapeState, MonsterTe
   public readonly name = 'extract:monster-template-modifications';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<MonsterTemplateModificationsOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -393,6 +407,12 @@ export type FinalizeMonsterTemplateOutput = 'success';
 class FinalizeMonsterTemplateNode extends ScalarNode<ScrapeState, FinalizeMonsterTemplateOutput> {
   public readonly name = 'finalize:monster-template';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeMonsterTemplateOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/monster/abilities.ts
+++ b/plugins/aonprd/concepts/monster/abilities.ts
@@ -5,7 +5,7 @@
  * extractMonsterAbilities, monsterAbilitiesNode.
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import { load, type CheerioAPI } from 'cheerio';
 import type { Element, AnyNode } from 'domhandler';
 
@@ -260,6 +260,22 @@ export type MonsterAbilitiesOutput = 'success' | 'error';
 class MonsterAbilitiesNode extends ScalarNode<ScrapeState, MonsterAbilitiesOutput> {
   public readonly name = 'extract:monster-abilities';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<MonsterAbilitiesOutput, SchemaObjectType> {
+    return {
+      // state.output merged with MonsterAbilitiesSlice (top_abilities, defensive_abilities, offensive_abilities arrays)
+      success: {
+        type: 'object',
+        properties: {
+          top_abilities:        { type: 'array', items: { type: 'object' } },
+          defensive_abilities:  { type: 'array', items: { type: 'object' } },
+          offensive_abilities:  { type: 'array', items: { type: 'object' } },
+        },
+        required: ['top_abilities', 'defensive_abilities', 'offensive_abilities'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/monster/base.ts
+++ b/plugins/aonprd/concepts/monster/base.ts
@@ -5,7 +5,7 @@
  * extractMonsterBase, monsterBaseNode.
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState } from '../../../../src/state/ScrapeState.js';
@@ -124,6 +124,14 @@ export type MonsterBaseOutput = 'success' | 'error';
 class MonsterBaseNode extends ScalarNode<ScrapeState, MonsterBaseOutput> {
   public readonly name = 'extract:monster-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<MonsterBaseOutput, SchemaObjectType> {
+    return {
+      // state.output merged with MonsterBaseSlice (url, monster_id, name, level, rarity, traits, source, perception, languages, skills, abilities, items, etc.)
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/monster/defenses.ts
+++ b/plugins/aonprd/concepts/monster/defenses.ts
@@ -4,7 +4,7 @@
  * Exports: splitBodySections, extractMonsterDefenses, monsterDefensesNode.
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { ScrapeState } from '../../../../src/state/ScrapeState.js';
 import { CAPABILITY_OUTPUTS } from '../../common.js';
@@ -30,6 +30,14 @@ export type MonsterDefensesOutput = 'success' | 'error';
 class MonsterDefensesNodeImpl extends ScalarNode<ScrapeState, MonsterDefensesOutput> {
   public readonly name    = 'extract:monster-defenses';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<MonsterDefensesOutput, SchemaObjectType> {
+    return {
+      // state.output merged with MonsterDefensesSlice (ac, saves, hp, hardness, immunities, weaknesses, resistances)
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/monster/finalize.ts
+++ b/plugins/aonprd/concepts/monster/finalize.ts
@@ -5,7 +5,7 @@
  * Strips claimed field labels from raw_fields and assembles final MonsterOutput.
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState } from '../../../../src/state/ScrapeState.js';
@@ -102,6 +102,13 @@ export type FinalizeMonsterOutput = 'success';
 class FinalizeMonsterNodeImpl extends ScalarNode<ScrapeState, FinalizeMonsterOutput> {
   public readonly name = 'finalize:monster';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeMonsterOutput, SchemaObjectType> {
+    return {
+      // setConceptOutput writes fully assembled MonsterOutput to state.output
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/monster/meta.ts
+++ b/plugins/aonprd/concepts/monster/meta.ts
@@ -4,7 +4,7 @@
  * Exports: parseFamilyLinks, extractVariants, extractMonsterMeta, monsterMetaNode.
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState } from '../../../../src/state/ScrapeState.js';
@@ -60,6 +60,21 @@ export type MonsterMetaOutput = 'success' | 'error';
 class MonsterMetaNode extends ScalarNode<ScrapeState, MonsterMetaOutput> {
   public readonly name = 'extract:monster-meta';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<MonsterMetaOutput, SchemaObjectType> {
+    return {
+      // state.output merged with MonsterMetaSlice (variants array, family_links array)
+      success: {
+        type: 'object',
+        properties: {
+          variants:     { type: 'array', items: { type: 'object' } },
+          family_links: { type: 'array', items: { type: 'object' } },
+        },
+        required: ['variants', 'family_links'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/monster/offense.ts
+++ b/plugins/aonprd/concepts/monster/offense.ts
@@ -4,7 +4,7 @@
  * Exports: extractMonsterOffense, monsterOffenseNode.
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState } from '../../../../src/state/ScrapeState.js';
@@ -25,6 +25,14 @@ export type MonsterOffenseOutput = 'success' | 'error';
 class MonsterOffenseNode extends ScalarNode<ScrapeState, MonsterOffenseOutput> {
   public readonly name    = 'extract:monster-offense';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<MonsterOffenseOutput, SchemaObjectType> {
+    return {
+      // state.output merged with MonsterOffenseSlice (speed, strikes, spell_lists)
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/npc-theme-template.ts
+++ b/plugins/aonprd/concepts/npc-theme-template.ts
@@ -6,7 +6,7 @@
 // is a first-class slice rather than being embedded inside a monolithic
 // finalize function.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -268,6 +268,13 @@ class NpcThemeTemplateBaseNodeImpl extends ScalarNode<ScrapeState, NpcThemeTempl
   public readonly name    = 'extract:npc-theme-template-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<NpcThemeTemplateBaseOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -295,6 +302,13 @@ class NpcThemeTemplateTraitsModsNodeImpl extends ScalarNode<ScrapeState, NpcThem
   public readonly name    = 'extract:npc-theme-template-traits-mods';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<NpcThemeTemplateTraitsModsOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -321,6 +335,12 @@ export type FinalizeNpcThemeTemplateOutput = 'success';
 class FinalizeNpcThemeTemplateNodeImpl extends ScalarNode<ScrapeState, FinalizeNpcThemeTemplateOutput> {
   public readonly name    = 'finalize:npc-theme-template';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeNpcThemeTemplateOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/plane.ts
+++ b/plugins/aonprd/concepts/plane.ts
@@ -4,7 +4,7 @@
 // (mirrors the language concept pattern); the `legacy: true` flag already
 // carries that signal from the title extraction.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -375,6 +375,14 @@ class PlaneBaseNodeImpl extends ScalarNode<ScrapeState, PlaneBaseOutput> {
   public readonly name = 'extract:plane-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<PlaneBaseOutput, SchemaObjectType> {
+    return {
+      // state.output merged with PlaneBaseSlice + PlaneDenizensSlice fields
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -402,6 +410,20 @@ class PlaneCharacteristicsNodeImpl extends ScalarNode<ScrapeState, PlaneCharacte
   public readonly name = 'extract:plane-characteristics';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<PlaneCharacteristicsOutput, SchemaObjectType> {
+    return {
+      // state.output merged with PlaneCharacteristicsSlice (category: string|null, aspect: string|null)
+      success: {
+        type: 'object',
+        properties: {
+          category: { type: 'string' },
+          aspect:   { type: 'string' },
+        },
+      },
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -426,6 +448,27 @@ export type FinalizePlaneOutput = 'success';
 class FinalizePlaneNodeImpl extends ScalarNode<ScrapeState, FinalizePlaneOutput> {
   public readonly name = 'finalize:plane';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizePlaneOutput, SchemaObjectType> {
+    return {
+      // state.output gets description_text, description_html, sections, raw_fields, links, body_*, meta_*
+      success: {
+        type: 'object',
+        properties: {
+          description_text:  { type: 'string' },
+          description_html:  { type: 'string' },
+          sections:          { type: 'array', items: { type: 'object' } },
+          raw_fields:        { type: 'object' },
+          links:             { type: 'array', items: { type: 'object' } },
+          body_text:         { type: 'string' },
+          body_html:         { type: 'string' },
+          meta_description:  { type: 'string' },
+          meta_keywords:     { type: 'string' },
+        },
+        required: ['description_text', 'description_html', 'sections'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/relic.ts
+++ b/plugins/aonprd/concepts/relic.ts
@@ -2,7 +2,7 @@
 // Covers both single-gift pages (?ID=N) and aspect-aggregator pages
 // (?Aspect=N) under one concept.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -344,6 +344,13 @@ class RelicBaseNode extends ScalarNode<ScrapeState, RelicBaseOutput> {
   public readonly name = 'extract:relic-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<RelicBaseOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -368,6 +375,14 @@ export type RelicGiftOutput = 'success' | 'error';
 class RelicGiftNode extends ScalarNode<ScrapeState, RelicGiftOutput> {
   public readonly name = 'extract:relic-gift';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<RelicGiftOutput, SchemaObjectType> {
+    return {
+      // state.output merged with gift, aspects, milestones slices
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -397,6 +412,12 @@ export type FinalizeRelicOutput = 'success';
 class FinalizeRelicNode extends ScalarNode<ScrapeState, FinalizeRelicOutput> {
   public readonly name = 'finalize:relic';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeRelicOutput, SchemaObjectType> {
+    return {
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/ritual/base.ts
+++ b/plugins/aonprd/concepts/ritual/base.ts
@@ -5,7 +5,7 @@
  * Node: extract:ritual-base
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState } from '../../../../src/state/ScrapeState.js';
@@ -40,6 +40,14 @@ export type RitualBaseOutput = 'success' | 'error';
 class RitualBaseNode extends ScalarNode<ScrapeState, RitualBaseOutput> {
   public readonly name = 'extract:ritual-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<RitualBaseOutput, SchemaObjectType> {
+    return {
+      // state.output merged with RitualBaseSlice (url, spell_id, name, kind, rank, rarity, pfs, traits, source, etc.)
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/ritual/finalize.ts
+++ b/plugins/aonprd/concepts/ritual/finalize.ts
@@ -6,7 +6,7 @@
  * Node: finalize:ritual
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState } from '../../../../src/state/ScrapeState.js';
@@ -81,6 +81,13 @@ export type FinalizeRitualOutput = 'success';
 class FinalizeRitualNode extends ScalarNode<ScrapeState, FinalizeRitualOutput> {
   public readonly name = 'finalize:ritual';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<FinalizeRitualOutput, SchemaObjectType> {
+    return {
+      // setConceptOutput writes fully assembled SpellOutput to state.output
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/ritual/slices.ts
+++ b/plugins/aonprd/concepts/ritual/slices.ts
@@ -5,7 +5,7 @@
  * extract:ritual-heightened, extract:ritual-meta
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState } from '../../../../src/state/ScrapeState.js';
@@ -57,6 +57,14 @@ class RitualCastNode extends ScalarNode<ScrapeState, RitualCastOutput> {
   public readonly name = 'extract:ritual-cast';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<RitualCastOutput, SchemaObjectType> {
+    return {
+      // state.output merged with RitualCastSlice (cast, trigger, range, area, targets, defense, saving_throw, duration, cost, requirements)
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -91,6 +99,22 @@ export type RitualOutcomesOutput = 'success' | 'error';
 class RitualOutcomesNode extends ScalarNode<ScrapeState, RitualOutcomesOutput> {
   public readonly name = 'extract:ritual-outcomes';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<RitualOutcomesOutput, SchemaObjectType> {
+    return {
+      // state.output merged with RitualOutcomesSlice (description_html, description_text, outcomes)
+      success: {
+        type: 'object',
+        properties: {
+          description_html: { type: 'string' },
+          description_text: { type: 'string' },
+          outcomes:         { type: 'array', items: { type: 'object' } },
+        },
+        required: ['description_html', 'description_text', 'outcomes'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -129,6 +153,14 @@ class RitualAfflictionNode extends ScalarNode<ScrapeState, RitualAfflictionOutpu
   public readonly name = 'extract:ritual-affliction';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<RitualAfflictionOutput, SchemaObjectType> {
+    return {
+      // state.output merged with RitualAfflictionSlice (affliction, ritual_primary_check, ritual_secondary_casters, ritual_secondary_checks)
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -156,6 +188,20 @@ export type RitualHeightenedOutput = 'success' | 'error';
 class RitualHeightenedNode extends ScalarNode<ScrapeState, RitualHeightenedOutput> {
   public readonly name = 'extract:ritual-heightened';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<RitualHeightenedOutput, SchemaObjectType> {
+    return {
+      // state.output merged with RitualHeightenedSlice (heightened array)
+      success: {
+        type: 'object',
+        properties: {
+          heightened: { type: 'array', items: { type: 'object' } },
+        },
+        required: ['heightened'],
+      },
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -212,6 +258,14 @@ export type RitualMetaOutput = 'success' | 'error';
 class RitualMetaNode extends ScalarNode<ScrapeState, RitualMetaOutput> {
   public readonly name = 'extract:ritual-meta';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<RitualMetaOutput, SchemaObjectType> {
+    return {
+      // state.output merged with RitualMetaSlice (traditions, spell_list, bloodlines, cult, domain, deities, mysteries, patron_themes, catalysts, lesson, access, spoiler_source)
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/rule.ts
+++ b/plugins/aonprd/concepts/rule.ts
@@ -19,7 +19,7 @@
 //
 // No `raw_fields` strip: rule pages have no `<b>Label</b>` field map.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import { load, type CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -315,6 +315,15 @@ class RuleBaseNode extends ScalarNode<ScrapeState, RuleBaseOutput> {
   public readonly name    = 'extract:rule-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with RuleBaseSlice (url, rule_id, name, source, sources, body_text, body_html)
+      success: { type: 'object' },
+      // `error` — aonprdCheerio metadata was absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -343,6 +352,15 @@ export type RuleSubsectionsOutput = 'success' | 'error';
 class RuleSubsectionsNode extends ScalarNode<ScrapeState, RuleSubsectionsOutput> {
   public readonly name    = 'extract:rule-subsections';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with RuleSubsectionsSlice (child_rules, sections)
+      success: { type: 'object' },
+      // `error` — aonprdCheerio metadata was absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -374,6 +392,19 @@ export type FinalizeRuleOutput = 'success';
 class FinalizeRuleConceptNode extends ScalarNode<ScrapeState, FinalizeRuleOutput> {
   public readonly name    = 'finalize:rule';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — state.output set to full RuleOutput via setConceptOutput
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/set-relic.ts
+++ b/plugins/aonprd/concepts/set-relic.ts
@@ -1,7 +1,7 @@
 //
 // SetRelics.aspx pages describe linked relic sets with tiered benefits.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -346,6 +346,15 @@ class SetRelicBaseNode extends ScalarNode<ScrapeState, SetRelicBaseOutput> {
   public readonly name = 'extract:set-relic-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SetRelicBaseSlice (url, set_relic_id, name, rarity, pfs, legacy, alt_edition_url, traits, trait_ids, source, sources)
+      success: { type: 'object' },
+      // `error` — aonprdCommon metadata was absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -371,6 +380,15 @@ class SetRelicComponentsNode extends ScalarNode<ScrapeState, SetRelicComponentsO
   public readonly name = 'extract:set-relic-components';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SetRelicComponentsSlice (aspects, components, gifts, features, description_text)
+      success: { type: 'object' },
+      // `error` — aonprdCommon metadata was absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -395,6 +413,19 @@ export type FinalizeSetRelicOutput = 'success';
 class FinalizeSetRelicNode extends ScalarNode<ScrapeState, FinalizeSetRelicOutput> {
   public readonly name = 'finalize:set-relic';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — state.output set to full SetRelicOutput via setConceptOutput
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/siege-weapon.ts
+++ b/plugins/aonprd/concepts/siege-weapon.ts
@@ -2,7 +2,7 @@
 // SiegeWeapons.aspx pages document large ranged engines with body-resident
 // stat-block fields and operator action definitions.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -449,6 +449,15 @@ class SiegeWeaponBaseNode extends ScalarNode<ScrapeState, SiegeWeaponBaseOutput>
   public readonly name = 'extract:siege-weapon-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SiegeWeaponBaseSlice (url, siege_weapon_id, name, level, rarity, pfs, legacy, alt_edition_url, traits, trait_ids, source, sources)
+      success: { type: 'object' },
+      // `error` — aonprdCommon metadata was absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -474,6 +483,15 @@ class SiegeWeaponMechanicsNode extends ScalarNode<ScrapeState, SiegeWeaponMechan
   public readonly name = 'extract:siege-weapon-mechanics';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SiegeWeaponMechanicsSlice (price, ammunition, usage, space, crew, proficiency, ac, fort, ref, hardness, hp, broken_threshold, immunities, speed)
+      success: { type: 'object' },
+      // `error` — aonprdCommon metadata was absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -498,6 +516,19 @@ export type FinalizeSiegeWeaponOutput = 'success';
 class FinalizeSiegeWeaponNode extends ScalarNode<ScrapeState, FinalizeSiegeWeaponOutput> {
   public readonly name = 'finalize:siege-weapon';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — state.output set to full SiegeWeaponOutput via setConceptOutput
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/skill/concept.ts
+++ b/plugins/aonprd/concepts/skill/concept.ts
@@ -1,6 +1,6 @@
 // Skill concept — DAG nodes and concept declaration.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
 import type { ConceptDecl } from '../../taxonomy.js';
@@ -19,6 +19,15 @@ export type SkillBaseOutput = 'success' | 'error';
 class SkillBaseNode extends ScalarNode<ScrapeState, SkillBaseOutput> {
   public readonly name = 'extract:skill-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SkillBaseSlice
+      success: { type: 'object' },
+      // `error` — required metadata absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -47,6 +56,15 @@ class SkillActionsNode extends ScalarNode<ScrapeState, SkillActionsOutput> {
   public readonly name = 'extract:skill-actions';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SkillActionsSlice
+      success: { type: 'object' },
+      // `error` — required metadata absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -74,6 +92,15 @@ class SkillProficiencyTiersNode extends ScalarNode<ScrapeState, SkillProficiency
   public readonly name = 'extract:skill-proficiency-tiers';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SkillProficiencyTiersSlice
+      success: { type: 'object' },
+      // `error` — required metadata absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -100,6 +127,19 @@ export type FinalizeSkillOutput = 'success';
 class FinalizeSkillNode extends ScalarNode<ScrapeState, FinalizeSkillOutput> {
   public readonly name = 'finalize:skill';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — state.output set to full SkillOutput via setConceptOutput
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/source.ts
+++ b/plugins/aonprd/concepts/source.ts
@@ -4,7 +4,7 @@
 // catalog of every entity sourced from that book organized by h2 category
 // headings. Helpers are inlined with inline contracts.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -308,6 +308,15 @@ class SourceBaseNodeImpl extends ScalarNode<ScrapeState, SourceBaseOutput> {
   public readonly name    = 'extract:source-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SourceBaseSlice
+      success: { type: 'object' },
+      // `error` — required metadata absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -331,6 +340,15 @@ export type SourceMetadataOutput = 'success' | 'error';
 class SourceMetadataNodeImpl extends ScalarNode<ScrapeState, SourceMetadataOutput> {
   public readonly name    = 'extract:source-metadata';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SourceMetadataSlice
+      success: { type: 'object' },
+      // `error` — required metadata absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -356,6 +374,15 @@ class SourceRelatedNodeImpl extends ScalarNode<ScrapeState, SourceRelatedOutput>
   public readonly name    = 'extract:source-related';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SourceRelatedSlice
+      success: { type: 'object' },
+      // `error` — required metadata absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -380,6 +407,19 @@ export type FinalizeSourceOutput = 'success';
 class FinalizeSourceNodeImpl extends ScalarNode<ScrapeState, FinalizeSourceOutput> {
   public readonly name    = 'finalize:source';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — state.output set to full SourceOutput via setConceptOutput
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/spell/affliction.ts
+++ b/plugins/aonprd/concepts/spell/affliction.ts
@@ -5,7 +5,7 @@
  * Node: extract:spell-affliction
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
 import type { CommonExtraction } from '../../common.js';
@@ -33,6 +33,15 @@ export type SpellAfflictionOutput = 'success' | 'error';
 class SpellAfflictionNodeImpl extends ScalarNode<ScrapeState, SpellAfflictionOutput> {
   public readonly name    = 'extract:spell-affliction';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SpellAfflictionSlice (affliction, ritual_primary_check, ritual_secondary_casters, ritual_secondary_checks)
+      success: { type: 'object' },
+      // `error` — required metadata absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/spell/base.ts
+++ b/plugins/aonprd/concepts/spell/base.ts
@@ -5,7 +5,7 @@
  * Node: extract:spell-base
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
@@ -40,6 +40,15 @@ export type SpellBaseOutput = 'success' | 'error';
 class SpellBaseNodeImpl extends ScalarNode<ScrapeState, SpellBaseOutput> {
   public readonly name = 'extract:spell-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SpellBaseSlice
+      success: { type: 'object' },
+      // `error` — required metadata absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/spell/cast.ts
+++ b/plugins/aonprd/concepts/spell/cast.ts
@@ -5,7 +5,7 @@
  * Node: extract:spell-cast
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
 import type { CommonExtraction } from '../../common.js';
@@ -35,6 +35,15 @@ export type SpellCastOutput = 'success' | 'error';
 class SpellCastNode extends ScalarNode<ScrapeState, SpellCastOutput> {
   public readonly name = 'extract:spell-cast';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SpellCastSlice (cast, trigger, range, area, targets, defense, saving_throw, duration, cost, requirements)
+      success: { type: 'object' },
+      // `error` — required metadata absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/spell/finalize.ts
+++ b/plugins/aonprd/concepts/spell/finalize.ts
@@ -6,7 +6,7 @@
  * at strip time. Node: finalize:spell
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
@@ -100,6 +100,19 @@ export type FinalizeSpellOutput = 'success';
 class FinalizeSpellNode extends ScalarNode<ScrapeState, FinalizeSpellOutput> {
   public readonly name    = 'finalize:spell';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — state.output set to full SpellOutput via setConceptOutput
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/spell/heightened.ts
+++ b/plugins/aonprd/concepts/spell/heightened.ts
@@ -5,7 +5,7 @@
  * Node: extract:spell-heightened
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
 import type { CommonExtraction } from '../../common.js';
@@ -26,6 +26,15 @@ export type SpellHeightenedOutput = 'success' | 'error';
 class SpellHeightenedNode extends ScalarNode<ScrapeState, SpellHeightenedOutput> {
   public readonly name = 'extract:spell-heightened';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SpellHeightenedSlice
+      success: { type: 'object' },
+      // `error` — required metadata absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/spell/meta.ts
+++ b/plugins/aonprd/concepts/spell/meta.ts
@@ -6,7 +6,7 @@
  * Node: extract:spell-meta
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
@@ -60,6 +60,15 @@ export type SpellMetaOutput = 'success' | 'error';
 class SpellMetaNode extends ScalarNode<ScrapeState, SpellMetaOutput> {
   public readonly name = 'extract:spell-meta';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SpellMetaSlice
+      success: { type: 'object' },
+      // `error` — required metadata absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/spell/outcomes.ts
+++ b/plugins/aonprd/concepts/spell/outcomes.ts
@@ -5,7 +5,7 @@
  * Node: extract:spell-outcomes
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
 import type { CommonExtraction } from '../../common.js';
@@ -31,6 +31,15 @@ export type SpellOutcomesOutput = 'success' | 'error';
 class SpellOutcomesNodeImpl extends ScalarNode<ScrapeState, SpellOutcomesOutput> {
   public readonly name = 'extract:spell-outcomes';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SpellOutcomesSlice
+      success: { type: 'object' },
+      // `error` — required metadata absent; no state mutation
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/subclass-feature/concept.ts
+++ b/plugins/aonprd/concepts/subclass-feature/concept.ts
@@ -1,6 +1,6 @@
 // Subclass-feature concept — DAG nodes and concept declaration.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
 import type { ConceptDecl } from '../../taxonomy.js';
@@ -16,6 +16,14 @@ export type SubclassFeatureBaseOutput = 'success' | 'error';
 class SubclassFeatureBaseNodeImpl extends ScalarNode<ScrapeState, SubclassFeatureBaseOutput> {
   public readonly name    = 'extract:subclass-feature-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SubclassFeatureBaseSlice (url, name, traits, sources, etc.)
+      success: { type: 'object' },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -41,6 +49,14 @@ class SubclassFeatureFieldsNodeImpl extends ScalarNode<ScrapeState, SubclassFeat
   public readonly name    = 'extract:subclass-feature-fields';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SubclassFeatureFieldsSlice
+      success: { type: 'object' },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -64,6 +80,14 @@ export type SubclassFeatureSpellsOutput = 'success' | 'error';
 class SubclassFeatureSpellsNodeImpl extends ScalarNode<ScrapeState, SubclassFeatureSpellsOutput> {
   public readonly name    = 'extract:subclass-feature-spells';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SubclassFeatureSpellsSlice
+      success: { type: 'object' },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -89,6 +113,14 @@ class SubclassFeatureFeaturesNodeImpl extends ScalarNode<ScrapeState, SubclassFe
   public readonly name    = 'extract:subclass-feature-features';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with SubclassFeatureFeaturesSlice
+      success: { type: 'object' },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -112,6 +144,19 @@ export type FinalizeSubclassFeatureOutput = 'success';
 class FinalizeSubclassFeatureNodeImpl extends ScalarNode<ScrapeState, FinalizeSubclassFeatureOutput> {
   public readonly name    = 'finalize:subclass-feature';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — state.output set to full SubclassFeatureOutput via setConceptOutput
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/tactic.ts
+++ b/plugins/aonprd/concepts/tactic.ts
@@ -5,7 +5,7 @@
 // Output is
 // bespoke node-folder under nodes/tactic/.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -220,6 +220,14 @@ class TacticBaseNodeImpl extends ScalarNode<ScrapeState, TacticBaseOutput> {
   public readonly name    = 'extract:tactic-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with TacticBaseSlice (url, tactic_id, name, rarity, traits, action_cost, category, source, sources, pfs, legacy, alt_edition_url)
+      success: { type: 'object' },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -244,6 +252,14 @@ class TacticMechanicsNodeImpl extends ScalarNode<ScrapeState, TacticMechanicsOut
   public readonly name    = 'extract:tactic-mechanics';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with TacticMechanicsSlice (prerequisites, requirements, trigger, frequency, effect, special)
+      success: { type: 'object' },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -267,6 +283,19 @@ export type FinalizeTacticOutput = 'success';
 class FinalizeTacticNodeImpl extends ScalarNode<ScrapeState, FinalizeTacticOutput> {
   public readonly name    = 'finalize:tactic';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — state.output set to full TacticOutput via setConceptOutput
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/trait/concept.ts
+++ b/plugins/aonprd/concepts/trait/concept.ts
@@ -1,5 +1,5 @@
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
@@ -19,6 +19,14 @@ export type TraitBaseOutput = 'success' | 'error';
 class TraitBaseNode extends ScalarNode<ScrapeState, TraitBaseOutput> {
   public readonly name    = 'extract:trait-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with TraitBaseSlice (from extractTraitBase)
+      success: { type: 'object' },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -42,6 +50,19 @@ export type FinalizeTraitOutput = 'success';
 class FinalizeTraitNode extends ScalarNode<ScrapeState, FinalizeTraitOutput> {
   public readonly name    = 'finalize:trait';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — state.output set to full TraitOutput via setConceptOutput
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/vehicle.ts
+++ b/plugins/aonprd/concepts/vehicle.ts
@@ -2,7 +2,7 @@
 // Vehicles.aspx pages document piloted transports with body-resident stat-block
 // fields, piloting checks, and operator action definitions.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -440,6 +440,14 @@ class VehicleBaseNodeImpl extends ScalarNode<ScrapeState, VehicleBaseOutput> {
   public readonly name = 'extract:vehicle-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with VehicleBaseSlice (url, vehicle_id, name, level, rarity, pfs, legacy, alt_edition_url, traits, trait_ids, source, sources)
+      success: { type: 'object' },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -464,6 +472,14 @@ class VehicleMechanicsNodeImpl extends ScalarNode<ScrapeState, VehicleMechanicsO
   public readonly name = 'extract:vehicle-mechanics';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with VehicleMechanicsSlice (price, space, crew, passengers, piloting_checks, ac, fort, ref, hardness, hp, broken_threshold, immunities, weaknesses, speed, collision)
+      success: { type: 'object' },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -487,6 +503,19 @@ export type FinalizeVehicleOutput = 'success';
 class FinalizeVehicleNodeImpl extends ScalarNode<ScrapeState, FinalizeVehicleOutput> {
   public readonly name = 'finalize:vehicle';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — state.output set to full VehicleOutput via setConceptOutput
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/weapon-group.ts
+++ b/plugins/aonprd/concepts/weapon-group.ts
@@ -2,7 +2,7 @@
 // Weapon-group pages have well-defined structure; the inlined helpers fully
 // cover the content shape.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -231,6 +231,14 @@ class WeaponGroupBaseNodeImpl extends ScalarNode<ScrapeState, WeaponGroupBaseOut
   public readonly name = 'extract:weapon-group-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with WeaponGroupBaseSlice (url, group_id, name, rarity, pfs, legacy, alt_edition_url, traits, trait_ids, source, sources)
+      success: { type: 'object' },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -254,6 +262,14 @@ export type WeaponGroupContentOutput = 'success' | 'error';
 class WeaponGroupContentNodeImpl extends ScalarNode<ScrapeState, WeaponGroupContentOutput> {
   public readonly name = 'extract:weapon-group-content';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with WeaponGroupContentSlice (critical_specialization_html, critical_specialization_text, weapons)
+      success: { type: 'object' },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -280,6 +296,13 @@ export type FinalizeWeaponGroupOutput = 'success';
 class FinalizeWeaponGroupNodeImpl extends ScalarNode<ScrapeState, FinalizeWeaponGroupOutput> {
   public readonly name = 'finalize:weapon-group';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with sections, raw_fields, links, body_text, body_html, meta_description, meta_keywords
+      success: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/weapon/concept.ts
+++ b/plugins/aonprd/concepts/weapon/concept.ts
@@ -7,7 +7,7 @@
  * the complete picture of claimed labels.
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { ScrapeState } from '../../../../src/state/ScrapeState.js';
 import type { ConceptDecl } from '../../taxonomy.js';
@@ -25,6 +25,14 @@ export type WeaponBaseOutput = 'success' | 'error';
 class WeaponBaseNode extends ScalarNode<ScrapeState, WeaponBaseOutput> {
   public readonly name = 'extract:weapon-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with WeaponBaseSlice
+      success: { type: 'object' },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,
@@ -50,6 +58,14 @@ export type WeaponMechanicsOutput = 'success' | 'error';
 class WeaponMechanicsNode extends ScalarNode<ScrapeState, WeaponMechanicsOutput> {
   public readonly name = 'extract:weapon-mechanics';
   public readonly outputs = CAPABILITY_OUTPUTS;
+
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with WeaponMechanicsSlice
+      success: { type: 'object' },
+      error:   { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/weapon/finalize.ts
+++ b/plugins/aonprd/concepts/weapon/finalize.ts
@@ -2,7 +2,7 @@
  * Weapon finalization — assemble final output and node interface.
  */
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState } from '../../../../src/state/ScrapeState.js';
@@ -45,6 +45,19 @@ export type FinalizeWeaponOutput = 'success';
 class FinalizeWeaponNode extends ScalarNode<ScrapeState, FinalizeWeaponOutput> {
   public readonly name = 'finalize:weapon';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — state.output set to full WeaponOutput via setConceptOutput
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/concepts/weather-hazard.ts
+++ b/plugins/aonprd/concepts/weather-hazard.ts
@@ -1,7 +1,7 @@
 //
 // the `legacy: true` flag already carries that signal from title extraction.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 import type { CheerioAPI } from 'cheerio';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
@@ -254,6 +254,14 @@ class WeatherHazardBaseNode extends ScalarNode<ScrapeState, WeatherHazardBaseOut
   public readonly name = 'extract:weather-hazard-base';
   public readonly outputs = CAPABILITY_OUTPUTS;
 
+  public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+    return {
+      // `success` — state.output merged with WeatherHazardBaseSlice + WeatherHazardEffectsSlice (url, weather_hazard_id, name, level, rarity, pfs, legacy, traits, source, sources, description, effects)
+      success: { type: 'object' },
+      error:   { type: 'object' },
+    };
+  }
+
   protected override async executeOne(
     state: ScrapeState,
     _ctx:  NodeContextType,
@@ -281,6 +289,19 @@ export type FinalizeWeatherHazardOutput = 'success';
 class FinalizeWeatherHazardNode extends ScalarNode<ScrapeState, FinalizeWeatherHazardOutput> {
   public readonly name = 'finalize:weather-hazard';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — state.output set to full WeatherHazardOutput via setConceptOutput
+      success: {
+        type: 'object',
+        properties: {
+          output: { type: 'object' },
+        },
+        required: ['output'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state: ScrapeState,

--- a/plugins/aonprd/index.ts
+++ b/plugins/aonprd/index.ts
@@ -17,3 +17,5 @@ import { TAXONOMY } from './taxonomy/aonprd.js';
 export function register(dispatcher: RipperDagonizer<ScrapeState>): void {
   for (const node of TAXONOMY.allNodes()) dispatcher.registerNode(node);
 }
+
+export { aonprdReconciler as reconciler } from './AonprdReconciler.js';

--- a/plugins/aonprd/nodes/loadAndCommon.ts
+++ b/plugins/aonprd/nodes/loadAndCommon.ts
@@ -8,7 +8,7 @@
 // plugin builds its own node via `makeLoadAndCommonNode(strategy)` and binds
 // the same Layer-1 capabilities downstream.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { ScrapeState }  from '../../../src/state/ScrapeState.js';
 import {
@@ -26,8 +26,8 @@ export type LoadAndCommonOutput = 'success' | 'error';
  * Inline contract:
  *   - `hardRequired: []` — `page.html` is external initial state, seeded into
  *     `ScrapeState.page.html` before the DAG runs. The DAG entrypoint is the
- *     URL router, not this node, so the `ContractRegistryValidator` would
- *     flag a `page.html` read as dangling. The runtime still reads
+ *     URL router, not this node, so DAGBuilder's explicit wiring does not
+ *     declare page.html as a produced metadata key. The runtime still reads
  *     `state.page.html` directly.
  *   - `produces: ['aonprdCheerio', 'aonprdCommon', 'aonprdTarget']` — the
  *     three metadata keys downstream Layer-1 capabilities consume.
@@ -45,7 +45,16 @@ export function makeLoadAndCommonNode(
   class LoadAndCommonNodeImpl extends ScalarNode<ScrapeState, LoadAndCommonOutput> {
     public readonly name    = 'aonprd:load-and-common';
     public readonly outputs = CAPABILITY_OUTPUTS;
-  
+
+    public override get outputSchema(): Record<'success' | 'error', SchemaObjectType> {
+      return {
+        // `success` — stashes aonprdCheerio (and aonprdCommon + aonprdTarget for non-rule pages) in metadata; no state.output mutation
+        success: { type: 'object' },
+        // `error` — page.html was absent or extractCommon returned null; no state mutation
+        error: { type: 'object' },
+      };
+    }
+
     protected override async executeOne(
       state:    ScrapeState,
       _context: NodeContextType,

--- a/plugins/aonprd/nodes/taxonomyRouter.ts
+++ b/plugins/aonprd/nodes/taxonomyRouter.ts
@@ -5,7 +5,7 @@
 // subsequent `aonprd:concept-dispatch` node can re-route after the shared
 // capability prefix.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { ScrapeState }    from '../../../src/state/ScrapeState.js';
 import type { CapabilityNode } from '../taxonomy.js';
@@ -36,6 +36,14 @@ export function makeTaxonomyRouter(
     public readonly name    = 'aonprd:taxonomy-route';
     public readonly outputs = outputs;
 
+    public override get outputSchema(): Record<string, SchemaObjectType> {
+      // Dynamic routing node — port names are concept IDs resolved at compile
+      // time. Routing to any port writes only the `aonprdConceptId` metadata key
+      // (not an enumerable state field), so every port carries the same
+      // open-object contract. Built from `outputs` so the schema covers every
+      // declared port, as the engine requires.
+      return Object.fromEntries(outputs.map((port): [string, SchemaObjectType] => [port, { type: 'object' }]));
+    }
 
     protected override async executeOne(
       state: ScrapeState,
@@ -73,6 +81,12 @@ export function makeConceptDispatch(
     public readonly name    = nodeName;
     public readonly outputs = outputs;
 
+    public override get outputSchema(): Record<string, SchemaObjectType> {
+      // Dynamic dispatch node — port names are concept IDs resolved at compile
+      // time. It only re-emits the stored `aonprdConceptId`; no state delta. Built
+      // from `outputs` so the schema covers every declared port.
+      return Object.fromEntries(outputs.map((port): [string, SchemaObjectType] => [port, { type: 'object' }]));
+    }
 
     protected override async executeOne(
       state: ScrapeState,

--- a/plugins/aonprd/nodes/unknownTerminal.ts
+++ b/plugins/aonprd/nodes/unknownTerminal.ts
@@ -2,7 +2,7 @@
 // Produces an UnknownOutput record for pages that did not match any type or
 // had a malformed content span. Writes to state.output and routes to success.
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { ScrapeState }   from '../../../src/state/ScrapeState.js';
 import { makeUnknown }        from '../concepts/generic/index.js';
@@ -10,6 +10,13 @@ import { makeUnknown }        from '../concepts/generic/index.js';
 class UnknownTerminalNode extends ScalarNode<ScrapeState, 'success'> {
   public readonly name = 'aonprd:make-unknown';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — state.output set to an UnknownOutput record (url field)
+      success: { type: 'object', properties: { output: { type: 'object' } }, required: ['output'] },
+    };
+  }
 
   // The node reads page.url from state directly (pre-seeded external state).
 

--- a/plugins/aonprd/page-raw.dag.jsonld
+++ b/plugins/aonprd/page-raw.dag.jsonld
@@ -89,7 +89,7 @@
       "outputs": {
         "success": "html:write-raw",
         "cached": "html:write-raw",
-        "error": "aonprd-page-raw:failed"
+        "error": "route:failure"
       }
     },
     {
@@ -102,16 +102,51 @@
       }
     },
     {
+      "@id": "urn:noocodex:dag:aonprd:page-raw/node/error:capture",
+      "@type": "SingleNode",
+      "name": "error:capture",
+      "node": "error:capture",
+      "outputs": {
+        "captured": "json:write"
+      }
+    },
+    {
+      "@id": "urn:noocodex:dag:aonprd:page-raw/node/route:failure",
+      "@type": "SingleNode",
+      "name": "route:failure",
+      "node": "route:failure",
+      "outputs": {
+        "retry": "html:fetch",
+        "resolve": "resolve:link",
+        "capture": "error:capture",
+        "expected": "aonprd-page-raw:completed"
+      }
+    },
+    {
+      "@id": "urn:noocodex:dag:aonprd:page-raw/node/resolve:link",
+      "@type": "SingleNode",
+      "name": "resolve:link",
+      "node": "resolve:link",
+      "outputs": {
+        "resolved": "html:fetch",
+        "unresolved": "error:capture"
+      }
+    },
+    {
+      "@id": "urn:noocodex:dag:aonprd:page-raw/node/json:write",
+      "@type": "SingleNode",
+      "name": "json:write",
+      "node": "json:write",
+      "outputs": {
+        "success": "aonprd-page-raw:completed",
+        "skipped": "aonprd-page-raw:completed"
+      }
+    },
+    {
       "@id": "urn:noocodex:dag:aonprd:page-raw/node/aonprd-page-raw:completed",
       "@type": "TerminalNode",
       "name": "aonprd-page-raw:completed",
       "outcome": "completed"
-    },
-    {
-      "@id": "urn:noocodex:dag:aonprd:page-raw/node/aonprd-page-raw:failed",
-      "@type": "TerminalNode",
-      "name": "aonprd-page-raw:failed",
-      "outcome": "failed"
     }
   ]
 }

--- a/plugins/aonprd/page-raw.dag.ts
+++ b/plugins/aonprd/page-raw.dag.ts
@@ -6,21 +6,29 @@
 import { DAGBuilder } from '@studnicky/dagonizer';
 import type { DAGType } from '@studnicky/dagonizer';
 
-import { HtmlFetchNode, HtmlWriteRawNode } from '../../src/nodes/index.js';
+import { HtmlFetchNode, HtmlWriteRawNode, JsonWriteNode, CaptureErrorNode, RouteFailureNode, ResolveLinkNode } from '../../src/nodes/index.js';
 
 const COMPLETED = 'aonprd-page-raw:completed';
-const FAILED    = 'aonprd-page-raw:failed';
+const CAPTURE   = 'error:capture';
 
 /**
  * The `aonprd:page-raw` plugin DAG — per-page raw-only chain for AON detail pages.
- * Chain: html:fetch → html:write-raw → completed
+ *
+ * Chain: html:fetch → html:write-raw → completed. A fetch failure routes to
+ * `error:capture`, which projects `state.errors` into an `{ _type: 'error' }`
+ * document that `json:write` persists — raw-pass fetch failures are inspectable
+ * data, not a swallowed exception.
+ *
  * @category Plugin DAGs
  */
 export const aonprdPageRawDAG: DAGType = (() => {
   const builder = new DAGBuilder('aonprd:page-raw', '1.0');
-  builder.node('html:fetch', HtmlFetchNode, { success: 'html:write-raw', cached: 'html:write-raw', error: FAILED });
+  builder.node('html:fetch', HtmlFetchNode, { success: 'html:write-raw', cached: 'html:write-raw', error: 'route:failure' });
   builder.node('html:write-raw', HtmlWriteRawNode, { success: COMPLETED });
+  builder.node(CAPTURE, CaptureErrorNode, { captured: 'json:write' });
+  builder.node('route:failure', RouteFailureNode, { retry: 'html:fetch', resolve: 'resolve:link', capture: CAPTURE, expected: COMPLETED });
+  builder.node('resolve:link', ResolveLinkNode, { resolved: 'html:fetch', unresolved: CAPTURE });
+  builder.node('json:write', JsonWriteNode, { success: COMPLETED, skipped: COMPLETED });
   builder.terminal(COMPLETED, { outcome: 'completed' });
-  builder.terminal(FAILED,    { outcome: 'failed' });
   return builder.build();
 })();

--- a/plugins/aonprd/page.dag.jsonld
+++ b/plugins/aonprd/page.dag.jsonld
@@ -89,7 +89,7 @@
       "outputs": {
         "success": "aonprd:parse",
         "cached": "aonprd:parse",
-        "error": "aonprd-page:failed"
+        "error": "route:failure"
       }
     },
     {
@@ -99,7 +99,7 @@
       "dag": "aonprd:parse",
       "outputs": {
         "success": "json:write",
-        "error": "aonprd-page:failed"
+        "error": "error:capture"
       },
       "stateMapping": {
         "input": {
@@ -108,6 +108,37 @@
         "output": {
           "output": "output"
         }
+      }
+    },
+    {
+      "@id": "urn:noocodex:dag:aonprd:page/node/error:capture",
+      "@type": "SingleNode",
+      "name": "error:capture",
+      "node": "error:capture",
+      "outputs": {
+        "captured": "json:write"
+      }
+    },
+    {
+      "@id": "urn:noocodex:dag:aonprd:page/node/route:failure",
+      "@type": "SingleNode",
+      "name": "route:failure",
+      "node": "route:failure",
+      "outputs": {
+        "retry": "html:fetch",
+        "resolve": "resolve:link",
+        "capture": "error:capture",
+        "expected": "aonprd-page:completed"
+      }
+    },
+    {
+      "@id": "urn:noocodex:dag:aonprd:page/node/resolve:link",
+      "@type": "SingleNode",
+      "name": "resolve:link",
+      "node": "resolve:link",
+      "outputs": {
+        "resolved": "html:fetch",
+        "unresolved": "error:capture"
       }
     },
     {
@@ -125,12 +156,6 @@
       "@type": "TerminalNode",
       "name": "aonprd-page:completed",
       "outcome": "completed"
-    },
-    {
-      "@id": "urn:noocodex:dag:aonprd:page/node/aonprd-page:failed",
-      "@type": "TerminalNode",
-      "name": "aonprd-page:failed",
-      "outcome": "failed"
     }
   ]
 }

--- a/plugins/aonprd/page.dag.ts
+++ b/plugins/aonprd/page.dag.ts
@@ -5,25 +5,33 @@ import { DAGBuilder } from '@studnicky/dagonizer';
 import type { DAGType } from '@studnicky/dagonizer';
 
 import type { ScrapeState } from '../../src/state/ScrapeState.js';
-import { HtmlFetchNode, JsonWriteNode } from '../../src/nodes/index.js';
+import { HtmlFetchNode, JsonWriteNode, CaptureErrorNode, RouteFailureNode, ResolveLinkNode } from '../../src/nodes/index.js';
 
 const COMPLETED = 'aonprd-page:completed';
-const FAILED    = 'aonprd-page:failed';
+const CAPTURE   = 'error:capture';
 
 /**
  * The `aonprd:page` plugin DAG — per-page chain for AON detail pages.
- * Chain: html:fetch → aonprd:parse (embedded) → json:write → completed
+ *
+ * Chain: html:fetch → aonprd:parse (embedded) → json:write → completed.
+ * The `error` ports of `html:fetch` and `aonprd:parse` route to `error:capture`,
+ * which projects `state.errors` into an `{ _type: 'error' }` document that
+ * `json:write` persists to disk — failures are written, inspectable data, not a
+ * swallowed exception (which is otherwise opaque across the worker boundary).
+ *
  * @category Plugin DAGs
  */
 export const aonprdPageDAG: DAGType = (() => {
   const builder = new DAGBuilder('aonprd:page', '1.0');
-  builder.node('html:fetch', HtmlFetchNode, { success: 'aonprd:parse', cached: 'aonprd:parse', error: FAILED });
-  builder.embeddedDAG<ScrapeState, ScrapeState>('aonprd:parse', 'aonprd:parse', { success: 'json:write', error: FAILED }, {
+  builder.node('html:fetch', HtmlFetchNode, { success: 'aonprd:parse', cached: 'aonprd:parse', error: 'route:failure' });
+  builder.embeddedDAG<ScrapeState, ScrapeState>('aonprd:parse', 'aonprd:parse', { success: 'json:write', error: CAPTURE }, {
     inputs:  { page: 'page' },
     outputs: { output: 'output' },
   });
+  builder.node(CAPTURE, CaptureErrorNode, { captured: 'json:write' });
+  builder.node('route:failure', RouteFailureNode, { retry: 'html:fetch', resolve: 'resolve:link', capture: CAPTURE, expected: COMPLETED });
+  builder.node('resolve:link', ResolveLinkNode, { resolved: 'html:fetch', unresolved: CAPTURE });
   builder.node('json:write', JsonWriteNode, { success: COMPLETED, skipped: COMPLETED });
   builder.terminal(COMPLETED, { outcome: 'completed' });
-  builder.terminal(FAILED,    { outcome: 'failed' });
   return builder.build();
 })();

--- a/plugins/aonprd/parse.taxonomic.ts
+++ b/plugins/aonprd/parse.taxonomic.ts
@@ -3,22 +3,12 @@
 // Uses the compiled AONPRD taxonomy to dispatch concept-specific capability
 // chains. Returns `state.output`; falls back to `{ url }` when the URL does
 // not match any concept and no fallback concept is configured.
-import { Batch } from '@studnicky/dagonizer';
-import type { NodeContextType } from '@studnicky/dagonizer';
+import { Batch }              from '@studnicky/dagonizer';
+import { NodeContextBuilder } from '@studnicky/dagonizer/entities';
 
 import { ScrapeState }  from '../../src/state/ScrapeState.js';
 import { TAXONOMY }     from './taxonomy/aonprd.js';
 
-// Minimal NodeContextType — direct-call invokers don't have a dispatcher,
-// so we synthesise the context shape the nodes receive when dispatched. The
-// node base reads `services`, `signal`, `dagName`, `nodeName` from context;
-// AONPRD capability nodes do not use services (TServices = undefined).
-const STUB_CONTEXT: NodeContextType<undefined> = {
-  services: undefined,
-  signal:   new AbortController().signal,
-  dagName:  'aonprd:parse:direct',
-  nodeName: 'aonprd:parse:direct',
-};
 
 /**
  * Parse an AON HTML page via the compiled AONPRD taxonomy. Looks up the
@@ -38,7 +28,7 @@ export async function parseAonHtmlTaxonomic(html: string, url: string): Promise<
 
   const chain = TAXONOMY.chainFor(conceptId);
   for (const node of chain) {
-    await node.execute(Batch.of(state), STUB_CONTEXT);
+    await node.execute(Batch.of(state), NodeContextBuilder.of('aonprd:parse:direct', 'aonprd:parse:direct', new AbortController().signal, undefined));
   }
 
   const output = state.output;

--- a/plugins/aonprd/taxonomy.ts
+++ b/plugins/aonprd/taxonomy.ts
@@ -42,10 +42,9 @@ type CapabilitySuccessErrorNode = NodeInterface<ScrapeState, 'success' | 'error'
 type CapabilityRouterNode       = NodeInterface<ScrapeState, string, unknown>;
 export type CapabilityNode = CapabilitySuccessOnlyNode | CapabilitySuccessErrorNode | CapabilityRouterNode;
 
-// A capability chain is a plain array of nodes. Chainability (each successor's
-// `hardRequired` ⊆ a predecessor's `produces`) is checked at the type layer via
-// dagonizer's native `ChainableType<A, B>`, and enforced at DAG-construction
-// time by `ContractRegistryValidator` (a `DAGError` on dangling-reads / dead-writes).
+// A capability chain is a plain array of nodes. Wiring is enforced at DAG-construction
+// time by DAGBuilder — a DAGError is thrown at registration when routing is misaligned
+// or a node references an undeclared port.
 
 /**
  * Declarative concept node in the taxonomy.

--- a/scripts/copy-dag-assets.mjs
+++ b/scripts/copy-dag-assets.mjs
@@ -3,31 +3,51 @@
 // `tsc` emits only `.js`/`.d.ts`; it never copies non-TS assets. Runtime loaders
 // read authored `.dag.jsonld` documents by a path relative to the COMPILED module
 // (e.g. `PluginLoader` loads `../crawlers/crawl-discover.dag.jsonld` via
-// `import.meta.dirname`, which resolves under `dist/` at runtime). Mirror every
-// authored `.dag.jsonld` under `src/` into the matching `dist/` location so the
-// built CLI finds them. Wired into `npm run build` after `tsc`.
+// `import.meta.dirname`). Two compiled trees exist and both need the assets:
+//
+//   • `dist/`         — the main CLI build (`tsc`, rootDir `src`). It loads only
+//                       the builtin `src/` assets; plugin documents are read from
+//                       the source `plugins/` tree at run time, never from dist/.
+//   • `dist-workers/` — the worker-thread build (`tsconfig.workers.json`, rootDir
+//                       `.`). Each `WorkerThreadContainer` boots a `DagHost` that
+//                       re-runs `PluginLoader` inside the worker, resolving asset
+//                       paths under `dist-workers/`. It therefore needs BOTH the
+//                       `src/` builtin assets and the `plugins/` documents.
+//
+// Wired into `npm run build` after the `tsc`/worker compiles.
 
-import { cpSync, mkdirSync, readdirSync, statSync } from 'node:fs';
-import { join, dirname, relative }                  from 'node:path';
+import { cpSync, mkdirSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, dirname, relative }                              from 'node:path';
 
-const SRC  = 'src';
-const DIST = 'dist';
+// Each target: the roots to scan, and how a source path maps to its dest.
+const targets = [
+  // Main CLI build: src/<p>.dag.jsonld → dist/<p>.dag.jsonld.
+  { dist: 'dist',         roots: ['src'],            rebase: (path, root) => join('dist', relative(root, path)) },
+  // Worker build: rootDir is the repo root, so the full path is preserved
+  // (src/<p> → dist-workers/src/<p>, plugins/<p> → dist-workers/plugins/<p>).
+  { dist: 'dist-workers', roots: ['src', 'plugins'], rebase: (path)       => join('dist-workers', path) },
+];
 
-const stack = [SRC];
 let copied = 0;
-while (stack.length > 0) {
-  const dir = stack.pop();
-  for (const name of readdirSync(dir)) {
-    const path = join(dir, name);
-    if (statSync(path).isDirectory()) {
-      stack.push(path);
-    } else if (name.endsWith('.dag.jsonld')) {
-      const dest = join(DIST, relative(SRC, path));
-      mkdirSync(dirname(dest), { recursive: true });
-      cpSync(path, dest);
-      copied += 1;
-      process.stdout.write(`  copied ${dest}\n`);
+for (const target of targets) {
+  if (!existsSync(target.dist)) continue;
+  for (const root of target.roots) {
+    const stack = [root];
+    while (stack.length > 0) {
+      const dir = stack.pop();
+      for (const name of readdirSync(dir)) {
+        const path = join(dir, name);
+        if (statSync(path).isDirectory()) {
+          stack.push(path);
+        } else if (name.endsWith('.dag.jsonld')) {
+          const dest = target.rebase(path, root);
+          mkdirSync(dirname(dest), { recursive: true });
+          cpSync(path, dest);
+          copied += 1;
+          process.stdout.write(`  copied ${dest}\n`);
+        }
+      }
     }
   }
 }
-process.stdout.write(`Copied ${copied.toString()} .dag.jsonld asset(s) into ${DIST}/\n`);
+process.stdout.write(`Copied ${copied.toString()} .dag.jsonld asset(s) into dist/ + dist-workers/\n`);

--- a/src/dispatcher/RipperDagonizer.ts
+++ b/src/dispatcher/RipperDagonizer.ts
@@ -6,14 +6,14 @@ import type { RipperServices } from '../services/RipperServices.js';
 
 const log = Logger.forComponent('Dispatcher');
 
-export type RipperDagonizerOptionsType<TState extends NodeStateInterface = NodeStateInterface> = {
+export type RipperDagonizerOptionsType = {
   readonly services: RipperServices;
   /**
    * Named container backends to bind to the dispatcher. Keys are the logical
    * role names declared on `embeddedDAG` placements (`container: '<role>'`).
    * When omitted, all placements run in-process (default behaviour).
    */
-  readonly containers?: Record<string, DagContainerInterface<TState>>;
+  readonly containers?: Record<string, DagContainerInterface>;
 };
 
 /**
@@ -29,7 +29,7 @@ export type RipperDagonizerOptionsType<TState extends NodeStateInterface = NodeS
 export class RipperDagonizer<TState extends NodeStateInterface>
   extends Dagonizer<TState, RipperServices> {
 
-  constructor(options: RipperDagonizerOptionsType<TState>) {
+  constructor(options: RipperDagonizerOptionsType) {
     super({
       services: options.services,
       ...(options.containers !== undefined ? { containers: options.containers } : {}),

--- a/src/nodes/CaptureErrorNode.ts
+++ b/src/nodes/CaptureErrorNode.ts
@@ -1,0 +1,81 @@
+import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
+
+import type { ScrapeState }    from '../state/ScrapeState.js';
+import type { RipperServices } from '../services/RipperServices.js';
+
+/**
+ * Projects the errors collected on `state.errors` into `state.output` as an
+ * inspectable error document, so a failing page persists a `{ _type: 'error' }`
+ * record (via the downstream `json:write`) instead of vanishing.
+ *
+ * Errors are data. A node that throws or routes its `error` port has its
+ * `NodeError` recorded on `state.errors`, but nothing writes that out — across
+ * the worker boundary a thrown exception is reduced to an opaque `error`
+ * partition with no detail. This node is the DAG route that makes per-page
+ * failures first-class, written, and inspectable: wire a node's `error` port to
+ * `error:capture`, then route `captured` to a write node.
+ *
+ * Output ports:
+ * - `captured` — `state.output` set to the error document.
+ *
+ * @category Nodes
+ * @since 4.3.0
+ */
+class CaptureErrorNodeImpl extends ScalarNode<ScrapeState, 'captured', RipperServices> {
+  public readonly name = 'error:capture';
+  public readonly outputs = ['captured'] as const;
+
+  public override get outputSchema(): Record<'captured', SchemaObjectType> {
+    return {
+      // `captured` — `state.output` holds the error document: the failing url
+      // and every `NodeError` collected on `state.errors`, projected to data.
+      captured: {
+        type: 'object',
+        properties: {
+          output: {
+            type: 'object',
+            properties: {
+              _type: { type: 'string' },
+              url:   { type: 'string' },
+              errors: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    code:      { type: 'string' },
+                    message:   { type: 'string' },
+                    operation: { type: 'string' },
+                    context:   { type: 'object' },
+                  },
+                  required: ['code', 'message', 'operation'],
+                },
+              },
+            },
+            required: ['_type', 'url', 'errors'],
+          },
+        },
+        required: ['output'],
+      },
+    };
+  }
+
+  protected override async executeOne(
+    state:    ScrapeState,
+    _context: NodeContextType<RipperServices>,
+  ): Promise<NodeOutputType<'captured'>> {
+    state.output = {
+      _type: 'error',
+      url:   state.page.url,
+      errors: state.errors.map((nodeError) => ({
+        code:      nodeError.code,
+        message:   nodeError.message,
+        operation: nodeError.operation,
+        context:   nodeError.context,
+      })),
+    };
+    return NodeOutputBuilder.of('captured');
+  }
+}
+
+export const CaptureErrorNode = new CaptureErrorNodeImpl();

--- a/src/nodes/HtmlFetchNode.ts
+++ b/src/nodes/HtmlFetchNode.ts
@@ -1,12 +1,15 @@
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
+import { BaseError } from '../errors/BaseError.js';
+import { HttpError } from '../errors/HttpError.js';
 import { ExternalSchemaError } from '../errors/ExternalSchemaError.js';
 import type { ScrapedPageType } from '../scrapers/HtmlScraper.js';
 import type { RawContentType } from '../types/PipelineState.js';
 import { toNodeError }              from './fileUtils.js';
 import type { ScrapeState }         from '../state/ScrapeState.js';
 import type { RipperServices }      from '../services/RipperServices.js';
+import { LAST_FAILURE_KEY }         from '../resilience/FailurePolicy.js';
 
 /** Returns true when the value looks like an HtmlScraper. */
 const isHtmlScraper = (val: unknown): val is { fetchPage(url: string): Promise<ScrapedPageType> } => {
@@ -23,7 +26,9 @@ type HtmlFetchOutput = 'success' | 'error' | 'cached';
  * Output ports:
  * - `success` — page fetched; `state.page.html` is populated.
  * - `cached`  — page was served from cache (no live HTTP); same fields set.
- * - `error`   — fetch failed (404, network error, etc); `state.failed` item recorded.
+ * - `error`   — fetch failed; failure context stashed under `LAST_FAILURE_KEY`
+ *   in state metadata. Route to `route:failure` for policy-driven routing
+ *   (retry / capture / resolve / expected).
  *
  * @category Nodes
  * @since 3.0.0
@@ -31,6 +36,49 @@ type HtmlFetchOutput = 'success' | 'error' | 'cached';
 class HtmlFetchNodeImpl extends ScalarNode<ScrapeState, HtmlFetchOutput, RipperServices> {
   public readonly name = 'html:fetch';
   public readonly outputs = ['success', 'error', 'cached'] as const;
+
+  public override get outputSchema(): Record<HtmlFetchOutput, SchemaObjectType> {
+    return {
+      // `success` — page fetched from network; `state.page` populated with url, html, and optional _raw.
+      success: {
+        type: 'object',
+        properties: {
+          page: {
+            type: 'object',
+            properties: {
+              targetId: { type: 'string' },
+              title:    { type: 'string' },
+              url:      { type: 'string' },
+              html:     { type: 'string' },
+              _raw:     { type: 'object' },
+            },
+            required: ['targetId', 'title', 'url', 'html'],
+          },
+        },
+        required: ['page'],
+      },
+      // `cached` — page served from cache; same `state.page` shape as `success`.
+      cached: {
+        type: 'object',
+        properties: {
+          page: {
+            type: 'object',
+            properties: {
+              targetId: { type: 'string' },
+              title:    { type: 'string' },
+              url:      { type: 'string' },
+              html:     { type: 'string' },
+              _raw:     { type: 'object' },
+            },
+            required: ['targetId', 'title', 'url', 'html'],
+          },
+        },
+        required: ['page'],
+      },
+      // `error` — fetch failed; FailurePolicy.ContextType stashed under LAST_FAILURE_KEY; route to route:failure.
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state:   ScrapeState,
@@ -62,9 +110,14 @@ class HtmlFetchNodeImpl extends ScalarNode<ScrapeState, HtmlFetchOutput, RipperS
     const fromCache = services.cache !== null && services.cache.has(url);
     try {
       result = await scraper.fetchPage(url);
+      // Fetched cleanly — reset the retry budget so a later re-entry starts fresh.
+      state.clearAttempts('html:fetch');
     } catch (err) {
+      // Stash failure context for `route:failure` to classify.
+      const status = err instanceof HttpError ? err.status : undefined;
+      const retryable = err instanceof BaseError ? err.retryable : true;
+      state.setMetadata(LAST_FAILURE_KEY, { url, status, retryable, phase: 'fetch', linkText: undefined });
       state.collectError(toNodeError(err, 'html:fetch'));
-      state.failed.push(url);
       return NodeOutputBuilder.of('error');
     }
 

--- a/src/nodes/HtmlWriteRawNode.ts
+++ b/src/nodes/HtmlWriteRawNode.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join }    from 'node:path';
 
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import { ExternalSchemaError } from '../errors/ExternalSchemaError.js';
 import { Logger }               from '../modules/logger/logger.js';
@@ -26,6 +26,13 @@ type HtmlWriteRawOutput = 'success';
 class HtmlWriteRawNodeImpl extends ScalarNode<ScrapeState, HtmlWriteRawOutput, RipperServices> {
   public readonly name = 'html:write-raw';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<HtmlWriteRawOutput, SchemaObjectType> {
+    return {
+      // `success` — raw HTML written to disk; no state delta.
+      success: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state:   ScrapeState,

--- a/src/nodes/JsonWriteNode.ts
+++ b/src/nodes/JsonWriteNode.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join }    from 'node:path';
 
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import { Logger }           from '../modules/logger/logger.js';
 import { pageSlug }         from './fileUtils.js';
@@ -30,6 +30,15 @@ type JsonWriteOutput = 'success' | 'skipped';
 class JsonWriteNodeImpl extends ScalarNode<ScrapeState, JsonWriteOutput, RipperServices> {
   public readonly name = 'json:write';
   public readonly outputs = ['success', 'skipped'] as const;
+
+  public override get outputSchema(): Record<JsonWriteOutput, SchemaObjectType> {
+    return {
+      // `success` — JSON file written to disk; no state delta.
+      success: { type: 'object' },
+      // `skipped` — `state.output` was null; no write performed; no state delta.
+      skipped: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state:   ScrapeState,

--- a/src/nodes/JsonlAppendNode.ts
+++ b/src/nodes/JsonlAppendNode.ts
@@ -2,7 +2,7 @@ import { mkdir, appendFile } from 'node:fs/promises';
 import { dirname, join }     from 'node:path';
 
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import { Logger }           from '../modules/logger/logger.js';
 import type { ScrapeState } from '../state/ScrapeState.js';
@@ -29,6 +29,15 @@ type JsonlAppendOutput = 'success' | 'skipped';
 class JsonlAppendNodeImpl extends ScalarNode<ScrapeState, JsonlAppendOutput, RipperServices> {
   public readonly name = 'jsonl:append';
   public readonly outputs = ['success', 'skipped'] as const;
+
+  public override get outputSchema(): Record<JsonlAppendOutput, SchemaObjectType> {
+    return {
+      // `success` — JSONL row appended to disk; no state delta.
+      success: { type: 'object' },
+      // `skipped` — `state.output` was null; no write performed; no state delta.
+      skipped: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state:   ScrapeState,

--- a/src/nodes/ReconcileIdentityNode.ts
+++ b/src/nodes/ReconcileIdentityNode.ts
@@ -1,0 +1,176 @@
+/**
+ * ReconcileIdentityNode — post-crawl identity reconciliation.
+ *
+ * Runs once in the MAIN process after the scatter completes, reading every
+ * per-page JSON doc the scatter wrote. Partitions docs into concepts and
+ * failures, builds an opaque identity index via the plugin's reconciler (or
+ * the default no-op), resolves each failure, writes the resolution back into
+ * the error doc on disk, and stashes a {@link ReconciliationSummaryType} in
+ * state metadata under {@link RECONCILIATION_KEY} for the downstream
+ * `report:crawl-health` node.
+ *
+ * Output ports:
+ * - `done` — reconciliation complete; summary available in metadata.
+ *
+ * @category Nodes
+ * @since 3.2.0
+ */
+
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
+
+import type { ScrapeState }    from '../state/ScrapeState.js';
+import type { RipperServices } from '../services/RipperServices.js';
+import {
+  RECONCILIATION_KEY,
+  defaultReconciler,
+} from '../resilience/Reconciler.js';
+import type {
+  ReconcilerInterface,
+  CapturedFailureType,
+  CapturedConceptType,
+  ReconciliationSummaryType,
+  ResolutionType,
+} from '../resilience/Reconciler.js';
+
+// ── ReconcileIdentityNode ──────────────────────────────────────────────────────
+
+class ReconcileIdentityNodeImpl extends ScalarNode<ScrapeState, 'done', RipperServices> {
+  public readonly name = 'reconcile:identity';
+  public readonly outputs = ['done'] as const;
+
+  public override get outputSchema(): Record<'done', SchemaObjectType> {
+    return {
+      // `done` — reconciliation summary stashed in state metadata under RECONCILIATION_KEY.
+      done: { type: 'object' },
+    };
+  }
+
+  /**
+   * Thread an opaque index through a typed reconciler without losing the
+   * `TIndex` type relationship between `prepare` and `resolveFailure`.
+   *
+   * The node never inspects `TIndex` — it just passes the value through.
+   * A generic private static method preserves the bound without requiring
+   * the caller to know `TIndex`.
+   */
+  private static applyReconciler<TIndex>(
+    reconciler: ReconcilerInterface<TIndex>,
+    failure: CapturedFailureType,
+    index: TIndex,
+  ): ResolutionType {
+    return reconciler.resolveFailure(failure, index);
+  }
+
+  protected override async executeOne(
+    state:   ScrapeState,
+    context: NodeContextType<RipperServices>,
+  ): Promise<NodeOutputType<'done'>> {
+    const { services } = context;
+    const dir = join(services.outDir, services.target.id, services.pluginTaskName ?? '');
+
+    // ── Read all per-page docs ───────────────────────────────────────────────
+    let files: string[] = [];
+    try {
+      files = readdirSync(dir).filter((file) => file.endsWith('.json'));
+    } catch {
+      // Directory absent (empty crawl) — treat as zero docs.
+    }
+
+    const concepts: Array<{ url: string; doc: Record<string, unknown>; file: string }> = [];
+    const failures: Array<{ failure: CapturedFailureType; file: string }> = [];
+
+    for (const file of files) {
+      const filePath = join(dir, file);
+      let doc: Record<string, unknown>;
+      try {
+        doc = JSON.parse(readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+
+      if (doc['_type'] === 'error') {
+        const url    = typeof doc['url'] === 'string' ? doc['url'] : filePath;
+        const errors = Array.isArray(doc['errors'])
+          ? (doc['errors'] as Array<{ code: string; message: string; operation: string }>)
+              .map((err) => ({ code: err.code ?? '', message: err.message ?? '', operation: err.operation ?? '' }))
+          : [];
+        failures.push({ failure: { url, errors }, file: filePath });
+      } else {
+        const url = typeof doc['url'] === 'string' ? doc['url'] : filePath;
+        concepts.push({ url, doc, file: filePath });
+      }
+    }
+
+    // ── Build identity index ─────────────────────────────────────────────────
+    const reconciler = services.reconciler ?? defaultReconciler;
+    const conceptList: CapturedConceptType[] = concepts.map((concept) => ({ url: concept.url, output: concept.doc }));
+    const index = reconciler.prepare(conceptList);
+
+    // ── Resolve each failure ─────────────────────────────────────────────────
+    let countCapturedElsewhere = 0;
+    let countMissing           = 0;
+    let countDead              = 0;
+
+    const capturedElsewhereList: Array<{ url: string; at: string }>  = [];
+    const missingList:           Array<{ url: string; errors: readonly { code: string; message: string }[] }> = [];
+    const deadList:              Array<{ url: string; reason: string }> = [];
+
+    for (const { failure, file } of failures) {
+      const resolution = ReconcileIdentityNodeImpl.applyReconciler(reconciler, failure, index);
+
+      // Write resolution back into the error doc on disk.
+      let existingDoc: Record<string, unknown> = {};
+      try {
+        existingDoc = JSON.parse(readFileSync(file, 'utf-8')) as Record<string, unknown>;
+      } catch {
+        // Fall back to empty doc if re-read fails.
+      }
+      const updated = { ...existingDoc, resolution };
+      writeFileSync(file, JSON.stringify(updated, null, 2), 'utf-8');
+
+      // Tally.
+      if (resolution.status === 'capturedElsewhere') {
+        countCapturedElsewhere++;
+        capturedElsewhereList.push({ url: failure.url, at: resolution.at });
+      } else if (resolution.status === 'missing') {
+        countMissing++;
+        missingList.push({ url: failure.url, errors: failure.errors });
+      } else {
+        countDead++;
+        deadList.push({ url: failure.url, reason: resolution.reason });
+      }
+    }
+
+    // ── Build and stash summary ──────────────────────────────────────────────
+    const summary: ReconciliationSummaryType = {
+      totals: {
+        concepts:           concepts.length,
+        failures:           failures.length,
+        capturedElsewhere:  countCapturedElsewhere,
+        missing:            countMissing,
+        dead:               countDead,
+      },
+      capturedElsewhere: capturedElsewhereList,
+      missing:           missingList,
+      dead:              deadList,
+    };
+
+    state.setMetadata(RECONCILIATION_KEY, summary);
+
+    services.log.info(
+      'reconcile:identity',
+      `${failures.length} failures: `
+      + `${countCapturedElsewhere} captured-elsewhere, `
+      + `${countMissing} missing, `
+      + `${countDead} dead`,
+    );
+
+    return NodeOutputBuilder.of('done');
+  }
+}
+
+export const ReconcileIdentityNode = new ReconcileIdentityNodeImpl();

--- a/src/nodes/ReportCrawlHealthNode.ts
+++ b/src/nodes/ReportCrawlHealthNode.ts
@@ -1,0 +1,78 @@
+/**
+ * ReportCrawlHealthNode — post-crawl health report writer.
+ *
+ * Runs once in the MAIN process after `reconcile:identity`. Reads the
+ * {@link ReconciliationSummaryType} stashed under {@link RECONCILIATION_KEY}
+ * and writes a human- and machine-readable `crawl-health.json` to
+ * `<outDir>/<target.id>/crawl-health.json`.
+ *
+ * Output ports:
+ * - `done` — report written to disk.
+ *
+ * @category Nodes
+ * @since 3.2.0
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+
+import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
+
+import type { ScrapeState }    from '../state/ScrapeState.js';
+import type { RipperServices } from '../services/RipperServices.js';
+import {
+  RECONCILIATION_KEY,
+} from '../resilience/Reconciler.js';
+import type { ReconciliationSummaryType } from '../resilience/Reconciler.js';
+
+// ── ReportCrawlHealthNode ──────────────────────────────────────────────────────
+
+class ReportCrawlHealthNodeImpl extends ScalarNode<ScrapeState, 'done', RipperServices> {
+  public readonly name = 'report:crawl-health';
+  public readonly outputs = ['done'] as const;
+
+  public override get outputSchema(): Record<'done', SchemaObjectType> {
+    return {
+      // `done` — crawl-health.json written to <outDir>/<target.id>/crawl-health.json.
+      done: { type: 'object' },
+    };
+  }
+
+  protected override async executeOne(
+    state:   ScrapeState,
+    context: NodeContextType<RipperServices>,
+  ): Promise<NodeOutputType<'done'>> {
+    const { services } = context;
+
+    const summary = state.getMetadata<ReconciliationSummaryType>(RECONCILIATION_KEY);
+
+    // If no summary is present (reconcile:identity was skipped), produce a
+    // minimal zero-totals report rather than failing.
+    const resolved: ReconciliationSummaryType = summary ?? {
+      totals: {
+        concepts: 0, failures: 0, capturedElsewhere: 0, missing: 0, dead: 0,
+      },
+      capturedElsewhere: [],
+      missing: [],
+      dead: [],
+    };
+
+    const report = {
+      generatedAt:       new Date().toISOString(),
+      target:            services.target.id,
+      totals:            resolved.totals,
+      capturedElsewhere: resolved.capturedElsewhere,
+      missing:           resolved.missing,
+      dead:              resolved.dead,
+    };
+
+    const outPath = join(services.outDir, services.target.id, 'crawl-health.json');
+    mkdirSync(dirname(outPath), { recursive: true });
+    writeFileSync(outPath, JSON.stringify(report, null, 2), 'utf-8');
+
+    return NodeOutputBuilder.of('done');
+  }
+}
+
+export const ReportCrawlHealthNode = new ReportCrawlHealthNodeImpl();

--- a/src/nodes/ResolveLinkNode.ts
+++ b/src/nodes/ResolveLinkNode.ts
@@ -1,0 +1,90 @@
+import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
+
+import type { ScrapeState }     from '../state/ScrapeState.js';
+import type { RipperServices }  from '../services/RipperServices.js';
+import { LAST_FAILURE_KEY }     from '../resilience/FailurePolicy.js';
+import type { FailureContextType } from '../resilience/FailurePolicy.js';
+import { LinkResolverRegistry } from '../resilience/LinkResolve.js';
+
+type ResolveLinkOutput = 'resolved' | 'unresolved';
+
+/**
+ * Opt-in link-resolution node that attempts to recover a wrong-locator URL
+ * before giving up. Runs after `route:failure` emits `resolve` and before
+ * `error:capture`.
+ *
+ * When a corrected URL is found, stashes it under `state.setMetadata('currentUrl', corrected)`
+ * so that the downstream `html:fetch` node picks it up.
+ *
+ * Output ports:
+ * - `resolved`   — a corrected URL was found; `currentUrl` metadata is updated.
+ * - `unresolved` — no strategy succeeded; route to `error:capture`.
+ *
+ * This node is strictly opt-in: with no `services.resolve` and no
+ * `'resolveStrategies'` metadata, it immediately routes `unresolved`.
+ * AON does not configure `services.resolve`, so for AON this node is dormant.
+ *
+ * @category Nodes
+ * @since 3.2.0
+ */
+class ResolveLinkNodeImpl extends ScalarNode<ScrapeState, ResolveLinkOutput, RipperServices> {
+  public readonly name = 'resolve:link';
+  public readonly outputs = ['resolved', 'unresolved'] as const;
+
+  public override get outputSchema(): Record<ResolveLinkOutput, SchemaObjectType> {
+    return {
+      // `resolved` — `currentUrl` metadata is set to the corrected URL.
+      // Metadata is not an enumerable state field; the key name is `currentUrl`.
+      resolved:   { type: 'object' },
+      // `unresolved` — no strategy succeeded; proceed to error:capture.
+      unresolved: { type: 'object' },
+    };
+  }
+
+  protected override async executeOne(
+    state:   ScrapeState,
+    context: NodeContextType<RipperServices>,
+  ): Promise<NodeOutputType<ResolveLinkOutput>> {
+    const { services } = context;
+
+    // Read the failed URL from stashed failure context, fall back to page URL.
+    const stashed = state.getMetadata<FailureContextType>(LAST_FAILURE_KEY);
+    const failedUrl = stashed?.url ?? state.page.url;
+
+    // Enforce resolve budget (default 2).
+    const budget  = services.resolve?.budget ?? 2;
+    const attempt = state.recordAttempt('resolve');
+    if (attempt > budget) {
+      state.clearAttempts('resolve');
+      return NodeOutputBuilder.of('unresolved');
+    }
+
+    // Strategy names: from metadata (set by route:failure) or from services config.
+    const strategyNames = state.getMetadata<string[]>('resolveStrategies')
+      ?? services.resolve?.strategies
+      ?? [];
+
+    if (strategyNames.length === 0) {
+      return NodeOutputBuilder.of('unresolved');
+    }
+
+    for (const name of strategyNames) {
+      const strategy = LinkResolverRegistry.get(name);
+      if (strategy === undefined) continue;
+
+      const corrected = await strategy.resolve(failedUrl, services);
+      if (corrected !== null) {
+        state.setMetadata('currentUrl', corrected);
+        services.log.info('resolve:link', `resolved ${failedUrl} → ${corrected} via ${name}`);
+        return NodeOutputBuilder.of('resolved');
+      }
+    }
+
+    // No strategy succeeded.
+    state.clearAttempts('resolve');
+    return NodeOutputBuilder.of('unresolved');
+  }
+}
+
+export const ResolveLinkNode = new ResolveLinkNodeImpl();

--- a/src/nodes/RouteFailureNode.ts
+++ b/src/nodes/RouteFailureNode.ts
@@ -1,0 +1,76 @@
+import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
+
+import type { ScrapeState }    from '../state/ScrapeState.js';
+import type { RipperServices } from '../services/RipperServices.js';
+import {
+  LAST_FAILURE_KEY,
+  defaultFailurePolicy,
+  type FailureContextType,
+} from '../resilience/FailurePolicy.js';
+
+type RouteFailureOutput = 'retry' | 'resolve' | 'capture' | 'expected';
+
+/**
+ * Policy-driven failure router. Reads the failure context stashed by the
+ * preceding node under `LAST_FAILURE_KEY`, increments the attempt counter,
+ * classifies the failure via `services.failurePolicy` (or the default policy),
+ * and emits the chosen route as its output port.
+ *
+ * Output ports:
+ * - `retry`    — transient failure within budget; wire back to `html:fetch`.
+ * - `resolve`  — permanent but potentially resolvable (Wave 3 opt-in).
+ * - `capture`  — permanent failure; url added to `state.failed`.
+ * - `expected` — known gap; counted as expected, not errored.
+ *
+ * @category Nodes
+ * @since 3.2.0
+ */
+class RouteFailureNodeImpl extends ScalarNode<ScrapeState, RouteFailureOutput, RipperServices> {
+  public readonly name = 'route:failure';
+  public readonly outputs = ['retry', 'resolve', 'capture', 'expected'] as const;
+
+  public override get outputSchema(): Record<RouteFailureOutput, SchemaObjectType> {
+    return {
+      // `retry` — transient failure within budget; attempt recorded, no state delta beyond that.
+      retry:    { type: 'object' },
+      // `resolve` — permanent but potentially resolvable; strategies stashed under 'resolveStrategies'.
+      resolve:  { type: 'object' },
+      // `capture` — permanent failure; url appended to `state.failed`.
+      capture:  { type: 'object' },
+      // `expected` — known gap; counted as expected outcome, not an error.
+      expected: { type: 'object' },
+    };
+  }
+
+  protected override async executeOne(
+    state:   ScrapeState,
+    context: NodeContextType<RipperServices>,
+  ): Promise<NodeOutputType<RouteFailureOutput>> {
+    const stashed = state.getMetadata<FailureContextType>(LAST_FAILURE_KEY);
+    if (stashed === undefined) {
+      state.failed.push(state.page.url);
+      return NodeOutputBuilder.of('capture');
+    }
+
+    const attempt = state.recordAttempt('html:fetch');
+    const failureContext: FailureContextType = { ...stashed, attempt };
+
+    const policy = context.services.failurePolicy ?? defaultFailurePolicy;
+    const decision = policy.classify(failureContext);
+
+    if (decision.route !== 'retry') {
+      state.clearAttempts('html:fetch');
+    }
+
+    if (decision.route === 'capture') {
+      state.failed.push(stashed.url);
+    } else if (decision.route === 'resolve') {
+      state.setMetadata('resolveStrategies', decision.strategies);
+    }
+
+    return NodeOutputBuilder.of(decision.route);
+  }
+}
+
+export const RouteFailureNode = new RouteFailureNodeImpl();

--- a/src/nodes/TerminalNode.ts
+++ b/src/nodes/TerminalNode.ts
@@ -1,5 +1,5 @@
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { ScrapeState }   from '../state/ScrapeState.js';
 import type { RipperServices } from '../services/RipperServices.js';
@@ -21,6 +21,13 @@ type TerminalOutput = 'success';
 class TerminalNodeImpl extends ScalarNode<ScrapeState, TerminalOutput, RipperServices> {
   public readonly name = 'flow:terminate';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<TerminalOutput, SchemaObjectType> {
+    return {
+      // `success` — no-op terminator; no state delta.
+      success: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     _state:   ScrapeState,

--- a/src/nodes/ValidateSchemaNode.ts
+++ b/src/nodes/ValidateSchemaNode.ts
@@ -4,7 +4,7 @@ import AjvModule, { type ValidateFunction } from 'ajv';
 import addFormatsModule from 'ajv-formats';
 
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { AjvCtorType, AddFormatsFnInterface } from '../types/AjvInterop.js';
 import { ExternalSchemaError } from '../errors/ExternalSchemaError.js';
@@ -70,6 +70,15 @@ type ValidateSchemaOutput = 'valid' | 'invalid';
 class ValidateSchemaNodeImpl extends ScalarNode<ScrapeState, ValidateSchemaOutput, RipperServices> {
   public readonly name = 'validate:schema';
   public readonly outputs = ['valid', 'invalid'] as const;
+
+  public override get outputSchema(): Record<ValidateSchemaOutput, SchemaObjectType> {
+    return {
+      // `valid` — `state.output` passed AJV validation (or no schema configured); no state delta.
+      valid: { type: 'object' },
+      // `invalid` — validation failed; error recorded on state via collectError; no other delta.
+      invalid: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state:   ScrapeState,

--- a/src/nodes/WikiFetchNode.ts
+++ b/src/nodes/WikiFetchNode.ts
@@ -1,5 +1,5 @@
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import { ExternalSchemaError } from '../errors/ExternalSchemaError.js';
 import type { WikiPageType } from '../types/MediaWikiScraper.js';
@@ -31,6 +31,30 @@ type WikiFetchOutput = 'success' | 'error';
 class WikiFetchNodeImpl extends ScalarNode<ScrapeState, WikiFetchOutput, RipperServices> {
   public readonly name = 'wiki:fetch';
   public readonly outputs = ['success', 'error'] as const;
+
+  public override get outputSchema(): Record<WikiFetchOutput, SchemaObjectType> {
+    return {
+      // `success` — `state.page` populated with targetId, title, url, and wikitext.
+      success: {
+        type: 'object',
+        properties: {
+          page: {
+            type: 'object',
+            properties: {
+              targetId: { type: 'string' },
+              title:    { type: 'string' },
+              url:      { type: 'string' },
+              wikitext: { type: 'string' },
+            },
+            required: ['targetId', 'title', 'url'],
+          },
+        },
+        required: ['page'],
+      },
+      // `error` — title missing, scraper invalid, or fetch failed; error recorded on state; `state.failed` may have title appended.
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state:   ScrapeState,

--- a/src/nodes/WikiWriteRawNode.ts
+++ b/src/nodes/WikiWriteRawNode.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join }    from 'node:path';
 
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import { ExternalSchemaError } from '../errors/ExternalSchemaError.js';
 import { Logger }               from '../modules/logger/logger.js';
@@ -26,6 +26,13 @@ type WikiWriteRawOutput = 'success';
 class WikiWriteRawNodeImpl extends ScalarNode<ScrapeState, WikiWriteRawOutput, RipperServices> {
   public readonly name = 'wiki:write-raw';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<WikiWriteRawOutput, SchemaObjectType> {
+    return {
+      // `success` — raw wikitext written to disk; no state delta.
+      success: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state:   ScrapeState,

--- a/src/nodes/crawl/CrawlExhaustedNode.ts
+++ b/src/nodes/crawl/CrawlExhaustedNode.ts
@@ -1,5 +1,5 @@
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { ScrapeState }    from '../../state/ScrapeState.js';
 import type { RipperServices } from '../../services/RipperServices.js';
@@ -24,6 +24,25 @@ const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'bas
 class CrawlExhaustedNodeImpl extends ScalarNode<ScrapeState, 'success', RipperServices> {
   public readonly name = 'crawl:exhausted';
   public readonly outputs = ['success'] as const;
+
+  public override get outputSchema(): Record<'success', SchemaObjectType> {
+    return {
+      // `success` — `state.crawl.discovered` sorted and capped to maxPages.
+      success: {
+        type: 'object',
+        properties: {
+          crawl: {
+            type: 'object',
+            properties: {
+              discovered: { type: 'array', items: { type: 'string' } },
+            },
+            required: ['discovered'],
+          },
+        },
+        required: ['crawl'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state:   ScrapeState,

--- a/src/nodes/crawl/DedupeAndEnqueueNode.ts
+++ b/src/nodes/crawl/DedupeAndEnqueueNode.ts
@@ -1,5 +1,5 @@
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { ScrapeState }    from '../../state/ScrapeState.js';
 import type { RipperServices } from '../../services/RipperServices.js';
@@ -35,6 +35,63 @@ class DedupeAndEnqueueNodeImpl extends ScalarNode<
 > {
   public readonly name = 'crawl:dedupe-and-enqueue';
   public readonly outputs = ['frontier-ready', 'frontier-empty', 'budget-exhausted'] as const;
+
+  public override get outputSchema(): Record<'frontier-ready' | 'frontier-empty' | 'budget-exhausted', SchemaObjectType> {
+    return {
+      // `frontier-ready` — next level frontier built; `state.crawl.frontier`, `discovered`, `depth` updated; raw accumulators cleared.
+      'frontier-ready': {
+        type: 'object',
+        properties: {
+          crawl: {
+            type: 'object',
+            properties: {
+              frontier:        { type: 'array', items: { type: 'string' } },
+              nextFrontierRaw: { type: 'array', items: { type: 'string' } },
+              discoveredRaw:   { type: 'array', items: { type: 'string' } },
+              discovered:      { type: 'array', items: { type: 'string' } },
+              depth:           { type: 'integer' },
+            },
+            required: ['frontier', 'nextFrontierRaw', 'discoveredRaw', 'discovered', 'depth'],
+          },
+        },
+        required: ['crawl'],
+      },
+      // `frontier-empty` — no traversable URLs remain; same crawl fields updated; frontier is empty array.
+      'frontier-empty': {
+        type: 'object',
+        properties: {
+          crawl: {
+            type: 'object',
+            properties: {
+              frontier:        { type: 'array', items: { type: 'string' } },
+              nextFrontierRaw: { type: 'array', items: { type: 'string' } },
+              discoveredRaw:   { type: 'array', items: { type: 'string' } },
+              discovered:      { type: 'array', items: { type: 'string' } },
+              depth:           { type: 'integer' },
+            },
+            required: ['frontier', 'nextFrontierRaw', 'discoveredRaw', 'discovered', 'depth'],
+          },
+        },
+        required: ['crawl'],
+      },
+      // `budget-exhausted` — maxPages or maxDepth limit reached; frontier and nextFrontierRaw cleared; discovered capped.
+      'budget-exhausted': {
+        type: 'object',
+        properties: {
+          crawl: {
+            type: 'object',
+            properties: {
+              frontier:        { type: 'array', items: { type: 'string' } },
+              nextFrontierRaw: { type: 'array', items: { type: 'string' } },
+              discovered:      { type: 'array', items: { type: 'string' } },
+            },
+            required: ['frontier', 'nextFrontierRaw', 'discovered'],
+          },
+        },
+        required: ['crawl'],
+      },
+    };
+  }
 
   protected override async executeOne(
     state:   ScrapeState,

--- a/src/nodes/crawl/FetchAndExtractLinksNode.ts
+++ b/src/nodes/crawl/FetchAndExtractLinksNode.ts
@@ -2,7 +2,7 @@ import { load } from 'cheerio';
 import type { Element } from 'domhandler';
 
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import { CrawlFetcher }        from './CrawlFetcher.js';
 import type { ScrapeState }    from '../../state/ScrapeState.js';
@@ -43,6 +43,45 @@ class FetchAndExtractLinksNodeImpl extends ScalarNode<
 > {
   public readonly name = 'crawl:fetch-and-extract';
   public readonly outputs = ['success', 'empty', 'error', 'permanent'] as const;
+
+  public override get outputSchema(): Record<'success' | 'empty' | 'error' | 'permanent', SchemaObjectType> {
+    return {
+      // `success` — links found; `state.crawl.visited`, `discoveredRaw`, and `nextFrontierRaw` updated.
+      success: {
+        type: 'object',
+        properties: {
+          crawl: {
+            type: 'object',
+            properties: {
+              visited:         { type: 'array', items: { type: 'string' } },
+              discoveredRaw:   { type: 'array', items: { type: 'string' } },
+              nextFrontierRaw: { type: 'array', items: { type: 'string' } },
+            },
+            required: ['visited', 'discoveredRaw', 'nextFrontierRaw'],
+          },
+        },
+        required: ['crawl'],
+      },
+      // `empty` — frontier empty or all pages fetched with no new links; `state.crawl.visited` updated.
+      empty: {
+        type: 'object',
+        properties: {
+          crawl: {
+            type: 'object',
+            properties: {
+              visited: { type: 'array', items: { type: 'string' } },
+            },
+            required: ['visited'],
+          },
+        },
+        required: ['crawl'],
+      },
+      // `error` — transient fetch failures occurred; `state.crawl.visited` may be partially updated.
+      error: { type: 'object' },
+      // `permanent` — all failures were 4xx permanent; no links found; no retry expected.
+      permanent: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state:   ScrapeState,

--- a/src/nodes/crawl/InitFrontierNode.ts
+++ b/src/nodes/crawl/InitFrontierNode.ts
@@ -1,5 +1,5 @@
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { ScrapeState }    from '../../state/ScrapeState.js';
 import type { RipperServices } from '../../services/RipperServices.js';
@@ -20,6 +20,36 @@ import type { RipperServices } from '../../services/RipperServices.js';
 class InitFrontierNodeImpl extends ScalarNode<ScrapeState, 'ready' | 'empty', RipperServices> {
   public readonly name = 'crawl:init-frontier';
   public readonly outputs = ['ready', 'empty'] as const;
+
+  public override get outputSchema(): Record<'ready' | 'empty', SchemaObjectType> {
+    return {
+      // `ready` — `state.crawl` is initialised with the seeded frontier and the
+      // crawl bookkeeping arrays/regex sources copied from `services.crawler`.
+      ready: {
+        type: 'object',
+        properties: {
+          crawl: {
+            type: 'object',
+            properties: {
+              frontier:        { type: 'array', items: { type: 'string' } },
+              nextFrontierRaw: { type: 'array', items: { type: 'string' } },
+              discoveredRaw:   { type: 'array', items: { type: 'string' } },
+              discovered:      { type: 'array', items: { type: 'string' } },
+              visited:         { type: 'array', items: { type: 'string' } },
+              depth:           { type: 'integer' },
+              domainRe:        { type: 'string' },
+              targetRe:        { type: 'string' },
+              delimiterRe:     { type: 'string' },
+            },
+            required: ['frontier', 'nextFrontierRaw', 'discoveredRaw', 'discovered', 'visited', 'depth', 'domainRe', 'targetRe', 'delimiterRe'],
+          },
+        },
+        required: ['crawl'],
+      },
+      // `empty` — short-circuit with no state delta (no crawler / empty seeds).
+      empty: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state:   ScrapeState,

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -1,8 +1,10 @@
 export { HtmlFetchNode }              from './HtmlFetchNode.js';
+export { RouteFailureNode }           from './RouteFailureNode.js';
 export { WikiFetchNode }              from './WikiFetchNode.js';
 export { HtmlWriteRawNode }           from './HtmlWriteRawNode.js';
 export { WikiWriteRawNode }           from './WikiWriteRawNode.js';
 export { JsonWriteNode }              from './JsonWriteNode.js';
+export { CaptureErrorNode }           from './CaptureErrorNode.js';
 export { JsonlAppendNode }            from './JsonlAppendNode.js';
 export { ValidateSchemaNode }         from './ValidateSchemaNode.js';
 export { TerminalNode }               from './TerminalNode.js';
@@ -10,3 +12,6 @@ export { InitFrontierNode }           from './crawl/InitFrontierNode.js';
 export { FetchAndExtractLinksNode }   from './crawl/FetchAndExtractLinksNode.js';
 export { DedupeAndEnqueueNode }       from './crawl/DedupeAndEnqueueNode.js';
 export { CrawlExhaustedNode }         from './crawl/CrawlExhaustedNode.js';
+export { ReconcileIdentityNode }      from './ReconcileIdentityNode.js';
+export { ReportCrawlHealthNode }      from './ReportCrawlHealthNode.js';
+export { ResolveLinkNode }            from './ResolveLinkNode.js';

--- a/src/nodes/wiki/ChooseModeNode.ts
+++ b/src/nodes/wiki/ChooseModeNode.ts
@@ -1,5 +1,5 @@
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { MemberResolutionState } from '../../state/MemberResolutionState.js';
 import type { RipperServices }        from '../../services/RipperServices.js';
@@ -27,6 +27,19 @@ type ChooseModeOutput = 'resume-failures' | 'single-category' | 'by-categories' 
 class ChooseModeNodeImpl extends ScalarNode<MemberResolutionState, ChooseModeOutput, RipperServices> {
   public readonly name = 'wiki:choose-mode';
   public readonly outputs = ['resume-failures', 'single-category', 'by-categories', 'all-pages'] as const;
+
+  public override get outputSchema(): Record<ChooseModeOutput, SchemaObjectType> {
+    return {
+      // `resume-failures` — routing decision only; no state delta.
+      'resume-failures':  { type: 'object' },
+      // `single-category` — routing decision only; no state delta.
+      'single-category':  { type: 'object' },
+      // `by-categories`   — routing decision only; no state delta.
+      'by-categories':    { type: 'object' },
+      // `all-pages`       — routing decision only; no state delta.
+      'all-pages':        { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state: MemberResolutionState,

--- a/src/nodes/wiki/FetchAllPagesNode.ts
+++ b/src/nodes/wiki/FetchAllPagesNode.ts
@@ -1,5 +1,5 @@
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { MediaWikiScraper }      from '../../scrapers/MediaWikiScraper.js';
 import { toNodeError }                from '../fileUtils.js';
@@ -31,6 +31,31 @@ type FetchAllPagesOutput = 'success' | 'error';
 class FetchAllPagesNodeImpl extends ScalarNode<MemberResolutionState, FetchAllPagesOutput, RipperServices> {
   public readonly name = 'wiki:fetch-all-pages';
   public readonly outputs = ['success', 'error'] as const;
+
+  public override get outputSchema(): Record<FetchAllPagesOutput, SchemaObjectType> {
+    return {
+      // `success` — `state.members` populated with all main-namespace page titles.
+      success: {
+        type: 'object',
+        properties: {
+          members: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                title:  { type: 'string' },
+                pageid: { type: 'integer' },
+              },
+              required: ['title', 'pageid'],
+            },
+          },
+        },
+        required: ['members'],
+      },
+      // `error` — scraper absent or API error; error recorded on state; no state delta.
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state:   MemberResolutionState,

--- a/src/nodes/wiki/FetchMultipleCategoriesNode.ts
+++ b/src/nodes/wiki/FetchMultipleCategoriesNode.ts
@@ -1,5 +1,5 @@
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { CategoryMemberType } from '../../types/MediaWikiScraper.js';
 import type { MediaWikiScraper }        from '../../scrapers/MediaWikiScraper.js';
@@ -28,6 +28,31 @@ type FetchMultipleCategoriesOutput = 'success' | 'error';
 class FetchMultipleCategoriesNodeImpl extends ScalarNode<MemberResolutionState, FetchMultipleCategoriesOutput, RipperServices> {
   public readonly name = 'wiki:fetch-multiple-categories';
   public readonly outputs = ['success', 'error'] as const;
+
+  public override get outputSchema(): Record<FetchMultipleCategoriesOutput, SchemaObjectType> {
+    return {
+      // `success` — `state.members` populated with deduplicated members from all config categories.
+      success: {
+        type: 'object',
+        properties: {
+          members: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                title:  { type: 'string' },
+                pageid: { type: 'integer' },
+              },
+              required: ['title', 'pageid'],
+            },
+          },
+        },
+        required: ['members'],
+      },
+      // `error` — scraper absent or API error; error recorded on state; no state delta.
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state:   MemberResolutionState,

--- a/src/nodes/wiki/FetchSingleCategoryNode.ts
+++ b/src/nodes/wiki/FetchSingleCategoryNode.ts
@@ -1,5 +1,5 @@
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { MediaWikiScraper }      from '../../scrapers/MediaWikiScraper.js';
 import { toNodeError }                from '../fileUtils.js';
@@ -27,6 +27,31 @@ type FetchSingleCategoryOutput = 'success' | 'error';
 class FetchSingleCategoryNodeImpl extends ScalarNode<MemberResolutionState, FetchSingleCategoryOutput, RipperServices> {
   public readonly name = 'wiki:fetch-single-category';
   public readonly outputs = ['success', 'error'] as const;
+
+  public override get outputSchema(): Record<FetchSingleCategoryOutput, SchemaObjectType> {
+    return {
+      // `success` — `state.members` populated with members of `state.category`.
+      success: {
+        type: 'object',
+        properties: {
+          members: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                title:  { type: 'string' },
+                pageid: { type: 'integer' },
+              },
+              required: ['title', 'pageid'],
+            },
+          },
+        },
+        required: ['members'],
+      },
+      // `error` — scraper absent, category undefined, or API error; error recorded on state; no state delta.
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state:   MemberResolutionState,

--- a/src/nodes/wiki/ResumeFailuresNode.ts
+++ b/src/nodes/wiki/ResumeFailuresNode.ts
@@ -2,7 +2,7 @@ import { readFile }   from 'node:fs/promises';
 import { resolve }    from 'node:path';
 
 import { ScalarNode, NodeOutputBuilder } from '@studnicky/dagonizer';
-import type { NodeContextType, NodeOutputType } from '@studnicky/dagonizer';
+import type { NodeContextType, NodeOutputType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { CategoryMemberType }  from '../../types/MediaWikiScraper.js';
 import type { FailuresManifestType } from '../../types/RipperRun.js';
@@ -26,6 +26,31 @@ type ResumeFailuresOutput = 'success' | 'error';
 class ResumeFailuresNodeImpl extends ScalarNode<MemberResolutionState, ResumeFailuresOutput, RipperServices> {
   public readonly name = 'wiki:resume-failures';
   public readonly outputs = ['success', 'error'] as const;
+
+  public override get outputSchema(): Record<ResumeFailuresOutput, SchemaObjectType> {
+    return {
+      // `success` — `state.members` populated from failures.json as synthetic CategoryMemberType entries (pageid 0).
+      success: {
+        type: 'object',
+        properties: {
+          members: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                title:  { type: 'string' },
+                pageid: { type: 'integer' },
+              },
+              required: ['title', 'pageid'],
+            },
+          },
+        },
+        required: ['members'],
+      },
+      // `error` — failures.json missing, unreadable, or malformed; error recorded on state; no state delta.
+      error: { type: 'object' },
+    };
+  }
 
   protected override async executeOne(
     state:   MemberResolutionState,

--- a/src/resilience/FailurePolicy.ts
+++ b/src/resilience/FailurePolicy.ts
@@ -1,0 +1,65 @@
+/**
+ * FailurePolicy — failure classification interface and default implementation.
+ *
+ * Types (`FailureContextType`, `FailureRouteType`) live in `src/types/FailurePolicy.ts`.
+ * This module provides the interface contract, the default implementation, and
+ * the shared metadata key used to stash failure context between nodes.
+ *
+ * @module resilience/FailurePolicy
+ * @since 3.2.0
+ */
+
+import type { FailureContextType, FailureRouteType } from '../types/FailurePolicy.js';
+
+export type { FailureContextType, FailureRouteType };
+
+/** Metadata key used to stash a {@link FailureContextType} between the failing node and `route:failure`. */
+export const LAST_FAILURE_KEY = 'lastFailure';
+
+/**
+ * Contract for classifying a node failure into a routing decision.
+ *
+ * Implement this interface to customise retry budgets, expected-gap lists,
+ * or resolution strategies. Pass the implementation as
+ * `services.failurePolicy` to override the default behaviour.
+ *
+ * @category Resilience
+ * @since 3.2.0
+ */
+export interface FailurePolicyInterface {
+  /**
+   * Classify a failure context into a routing decision.
+   *
+   * @param context - The failure context written by the failing node.
+   * @returns A {@link FailureRouteType} describing what to do next.
+   */
+  classify(context: FailureContextType): FailureRouteType;
+}
+
+/**
+ * Default failure policy: retry transient failures up to `maxRetries` times,
+ * then capture permanently.
+ *
+ * - `retryable && attempt <= maxRetries` → `retry`
+ * - otherwise → `capture`
+ *
+ * @category Resilience
+ * @since 3.2.0
+ */
+export class DefaultFailurePolicy implements FailurePolicyInterface {
+  private readonly maxRetries: number;
+
+  public constructor(maxRetries = 2) {
+    this.maxRetries = maxRetries;
+  }
+
+  public classify(context: FailureContextType): FailureRouteType {
+    if (context.retryable && context.attempt <= this.maxRetries) {
+      return { route: 'retry' };
+    }
+    return { route: 'capture' };
+  }
+}
+
+/** Singleton default policy instance; used when `services.failurePolicy` is absent. */
+export const defaultFailurePolicy = new DefaultFailurePolicy();

--- a/src/resilience/LinkResolve.ts
+++ b/src/resilience/LinkResolve.ts
@@ -1,0 +1,153 @@
+/**
+ * Link-resolution strategy contract and built-in implementations.
+ *
+ * @module resilience/LinkResolve
+ * @since 3.2.0
+ */
+
+import type { RipperServices } from '../services/RipperServices.js';
+
+/**
+ * Strategy for correcting a wrong-locator URL.
+ *
+ * Each built-in strategy is a class (noun) with a `resolve` instance method.
+ * The registry maps strategy names to instances.
+ *
+ * @category Resilience
+ * @since 3.2.0
+ */
+export interface LinkResolverStrategyInterface {
+  readonly name: string;
+  /**
+   * Attempt to resolve a corrected absolute URL for a failed URL.
+   *
+   * @returns A corrected absolute URL, or `null` when this strategy cannot resolve.
+   */
+  resolve(failedUrl: string, services: RipperServices): Promise<string | null>;
+}
+
+// ── Built-in strategy pattern ───────────────────────────────────────────────────
+// `<Category>.aspx?ID=<n>` shape used by AON.
+const CATEGORY_URL_RE = /^(https?:\/\/[^/]+)\/([^/]+\.aspx)\?ID=(\d+)$/i;
+
+// ── CrossLocatorStrategy ────────────────────────────────────────────────────────
+
+/**
+ * Tries sibling categories with the same numeric ID.
+ *
+ * Parses the `<Category>.aspx?ID=<n>` shape from `failedUrl`. For each
+ * category in `services.resolve?.categorySet` that differs from the failed
+ * category, builds a candidate url and probes via `htmlScraper.fetchPage`.
+ * Returns the first candidate that doesn't throw; `null` when none match or
+ * when the url doesn't match the expected pattern.
+ *
+ * @category Resilience
+ * @since 3.2.0
+ */
+class CrossLocatorStrategy implements LinkResolverStrategyInterface {
+  public readonly name = 'crossLocator';
+
+  public async resolve(failedUrl: string, services: RipperServices): Promise<string | null> {
+    const match = CATEGORY_URL_RE.exec(failedUrl);
+    if (match === null) return null;
+
+    const [, origin, failedAspx, numericId] = match as unknown as [string, string, string, string];
+    const failedCategory = failedAspx.toLowerCase();
+    const categorySet    = services.resolve?.categorySet ?? [];
+
+    for (const category of categorySet) {
+      const candidate = `${origin}/${category}.aspx?ID=${numericId}`;
+      if (candidate.toLowerCase().replace(/^https?:\/\/[^/]+\//, '').split('?')[0] === failedCategory) {
+        // Same category — skip.
+        continue;
+      }
+      try {
+        await services.htmlScraper?.fetchPage(candidate);
+        return candidate;
+      } catch {
+        // This candidate also failed — try the next one.
+      }
+    }
+
+    return null;
+  }
+}
+
+// ── SearchStrategy ─────────────────────────────────────────────────────────────
+
+/**
+ * Placeholder for a search-based resolution strategy.
+ *
+ * The `linkText` required for the search query lives on the failure context in
+ * state metadata, not on the `resolve(failedUrl, services)` signature. Until
+ * the strategy contract is extended to carry failure context, this strategy
+ * always returns `null`. It is retained as a named hook for future extension.
+ *
+ * @category Resilience
+ * @since 3.2.0
+ */
+class SearchStrategy implements LinkResolverStrategyInterface {
+  public readonly name = 'search';
+
+  public async resolve(_failedUrl: string, _services: RipperServices): Promise<string | null> {
+    // `linkText` is on the failure context in state metadata, not passed here.
+    // Returning null until the strategy contract is extended to carry failure context.
+    return null;
+  }
+}
+
+// ── CanonicalStrategy ──────────────────────────────────────────────────────────
+
+/**
+ * Fetches the failed URL and looks for a `<link rel="canonical" href="...">`.
+ *
+ * Returns the canonical href when present and different from `failedUrl`;
+ * `null` otherwise.
+ *
+ * @category Resilience
+ * @since 3.2.0
+ */
+class CanonicalStrategy implements LinkResolverStrategyInterface {
+  public readonly name = 'canonical';
+
+  public async resolve(failedUrl: string, services: RipperServices): Promise<string | null> {
+    let html: string;
+    try {
+      const result = await services.htmlScraper?.fetchPage(failedUrl);
+      if (result === undefined) return null;
+      html = result.html;
+    } catch {
+      return null;
+    }
+
+    const canonicalMatch = /<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']+)["']/i.exec(html)
+      ?? /<link[^>]+href=["']([^"']+)["'][^>]+rel=["']canonical["']/i.exec(html);
+
+    if (canonicalMatch === null) return null;
+    const href = canonicalMatch[1] as string;
+    return href !== failedUrl ? href : null;
+  }
+}
+
+// ── LinkResolverRegistry ───────────────────────────────────────────────────────
+
+class LinkResolverRegistryImpl {
+  private readonly entries: ReadonlyMap<string, LinkResolverStrategyInterface>;
+
+  public constructor() {
+    const crossLocator: LinkResolverStrategyInterface = new CrossLocatorStrategy();
+    const search:       LinkResolverStrategyInterface = new SearchStrategy();
+    const canonical:    LinkResolverStrategyInterface = new CanonicalStrategy();
+    this.entries = new Map<string, LinkResolverStrategyInterface>([
+      [crossLocator.name, crossLocator],
+      [search.name,       search],
+      [canonical.name,    canonical],
+    ]);
+  }
+
+  public get(name: string): LinkResolverStrategyInterface | undefined {
+    return this.entries.get(name);
+  }
+}
+
+export const LinkResolverRegistry = new LinkResolverRegistryImpl();

--- a/src/resilience/Reconciler.ts
+++ b/src/resilience/Reconciler.ts
@@ -1,0 +1,92 @@
+/**
+ * Reconciler — identity matching interface and default implementation.
+ *
+ * Types (`ResolutionType`, `CapturedFailureType`, `CapturedConceptType`,
+ * `ReconciliationSummaryType`) live in `src/types/Reconciler.ts`.
+ * This module provides the interface contract, the default implementation,
+ * and the shared metadata key used to hand the summary between nodes.
+ *
+ * @module resilience/Reconciler
+ * @since 3.2.0
+ */
+
+export type {
+  ResolutionType,
+  CapturedFailureType,
+  CapturedConceptType,
+  ReconciliationSummaryType,
+} from '../types/Reconciler.js';
+
+import type {
+  ResolutionType,
+  CapturedFailureType,
+  CapturedConceptType,
+} from '../types/Reconciler.js';
+
+/** Metadata key used to pass the reconciliation summary from `reconcile:identity` to `report:crawl-health`. */
+export const RECONCILIATION_KEY = 'reconciliation';
+
+/**
+ * Contract for identity-based failure resolution.
+ *
+ * Implement this interface to define what "identity" means for a target site
+ * and how a captured failure matches a known concept. Pass the implementation
+ * as `services.reconciler` to override the default conservative behaviour.
+ *
+ * The framework owns the mechanism (scan, prepare, aggregate); the plugin owns
+ * the semantics (what index shape to build, how to match failures).
+ *
+ * `TIndex` is the opaque index shape produced by `prepare` and consumed by
+ * `resolveFailure`. The node never inspects it — it just threads it through.
+ *
+ * @category Resilience
+ * @since 3.2.0
+ */
+export interface ReconcilerInterface<TIndex = unknown> {
+  /**
+   * Build an opaque identity index from the full set of successfully scraped
+   * concept docs.
+   *
+   * The returned index is passed verbatim to every `resolveFailure` call.
+   * The framework never reads or transforms it.
+   *
+   * @param concepts - All successfully scraped concept docs for this run.
+   * @returns An opaque index whose shape is defined by the implementation.
+   */
+  prepare(concepts: readonly CapturedConceptType[]): TIndex;
+
+  /**
+   * Decide the resolution status for a single captured failure.
+   *
+   * @param failure - The captured error document (url + error list).
+   * @param index   - The opaque index built by `prepare`.
+   * @returns A {@link ResolutionType} describing how the failure resolved.
+   */
+  resolveFailure(failure: CapturedFailureType, index: TIndex): ResolutionType;
+}
+
+/**
+ * Default reconciler: conservative no-op.
+ *
+ * `prepare` returns `null` (no indexing), so every failure resolves to
+ * `missing`. Targets without a plugin reconciler still produce a valid,
+ * complete report — just with all failures classified as missing.
+ *
+ * @category Resilience
+ * @since 3.2.0
+ */
+export class DefaultReconciler implements ReconcilerInterface<null> {
+  public prepare(_concepts: readonly CapturedConceptType[]): null {
+    return null;
+  }
+
+  public resolveFailure(
+    _failure: CapturedFailureType,
+    _index: null,
+  ): ResolutionType {
+    return { status: 'missing' };
+  }
+}
+
+/** Singleton default reconciler; used when `services.reconciler` is absent. */
+export const defaultReconciler = new DefaultReconciler();

--- a/src/run/PluginLoader.ts
+++ b/src/run/PluginLoader.ts
@@ -14,8 +14,9 @@ import { resolve }      from 'node:path';
 import { DAGDocument }            from '@studnicky/dagonizer';
 import type { DAGType }           from '@studnicky/dagonizer';
 
-import type { RipperDagonizer } from '../dispatcher/RipperDagonizer.js';
-import type { ScrapeState }     from '../state/ScrapeState.js';
+import type { RipperDagonizer }    from '../dispatcher/RipperDagonizer.js';
+import type { ScrapeState }        from '../state/ScrapeState.js';
+import type { ReconcilerInterface } from '../resilience/Reconciler.js';
 
 import {
   HtmlFetchNode,
@@ -23,6 +24,7 @@ import {
   HtmlWriteRawNode,
   WikiWriteRawNode,
   JsonWriteNode,
+  CaptureErrorNode,
   JsonlAppendNode,
   ValidateSchemaNode,
   TerminalNode,
@@ -30,6 +32,10 @@ import {
   FetchAndExtractLinksNode,
   DedupeAndEnqueueNode,
   CrawlExhaustedNode,
+  RouteFailureNode,
+  ReconcileIdentityNode,
+  ReportCrawlHealthNode,
+  ResolveLinkNode,
 } from '../nodes/index.js';
 
 // ── Builtin crawl DAG ──────────────────────────────────────────────────────────
@@ -59,7 +65,7 @@ export class PluginLoader {
    * `PluginLoader.registerBuiltinNodes`.
    */
   static readonly BUILTIN_PREFIXES: ReadonlyArray<string> = [
-    'html:', 'wiki:', 'json:', 'jsonl:', 'validate:', 'crawl:',
+    'html:', 'wiki:', 'json:', 'jsonl:', 'validate:', 'crawl:', 'route:', 'reconcile:', 'report:', 'resolve:',
   ];
 
   /**
@@ -76,6 +82,7 @@ export class PluginLoader {
     dispatcher.registerNode(HtmlWriteRawNode);
     dispatcher.registerNode(WikiWriteRawNode);
     dispatcher.registerNode(JsonWriteNode);
+    dispatcher.registerNode(CaptureErrorNode);
     dispatcher.registerNode(JsonlAppendNode);
     dispatcher.registerNode(ValidateSchemaNode);
     dispatcher.registerNode(TerminalNode);
@@ -84,6 +91,12 @@ export class PluginLoader {
     dispatcher.registerNode(FetchAndExtractLinksNode);
     dispatcher.registerNode(DedupeAndEnqueueNode);
     dispatcher.registerNode(CrawlExhaustedNode);
+    // Resilience nodes
+    dispatcher.registerNode(RouteFailureNode);
+    dispatcher.registerNode(ResolveLinkNode);
+    // Post-crawl analysis nodes (MAIN only)
+    dispatcher.registerNode(ReconcileIdentityNode);
+    dispatcher.registerNode(ReportCrawlHealthNode);
     // Builtin crawl DAG document
     dispatcher.registerDAG(
       DAGDocument.load(readFileSync(CRAWL_DISCOVER_DAG_PATH, 'utf-8')),
@@ -196,12 +209,16 @@ export class PluginLoader {
     return undefined;
   }
 
-  static async registerPluginsFromEntry(
-    dispatcher:    RipperDagonizer<ScrapeState>,
-    entryDag:      DAGType,
-    configDir:     string,
-  ): Promise<Set<string>> {
-    // Collect non-builtin dag-reference names from EmbeddedDAGNode and ScatterNode placements.
+  /**
+   * Collect the distinct plugin namespaces referenced by a DAG's placements.
+   *
+   * Scans `EmbeddedDAGNode` and `ScatterNode` placements for non-builtin
+   * dag-reference names, then extracts the namespace (the segment before `:`).
+   *
+   * @param entryDag - The orchestration DAG to inspect.
+   * @returns A `Set<string>` of distinct plugin namespaces.
+   */
+  private static extractNamespaces(entryDag: DAGType): Set<string> {
     const dagRefs = new Set<string>();
     for (const placement of entryDag.nodes) {
       let dagRef: string | undefined;
@@ -221,7 +238,6 @@ export class PluginLoader {
       }
     }
 
-    // Derive distinct plugin namespaces (the segment before `:`).
     const namespaces = new Set<string>();
     for (const ref of dagRefs) {
       const colon = ref.indexOf(':');
@@ -229,6 +245,62 @@ export class PluginLoader {
         namespaces.add(ref.slice(0, colon));
       }
     }
+
+    return namespaces;
+  }
+
+  /**
+   * Discover the first plugin reconciler exported by the entry DAG's plugin.
+   *
+   * Imports the same `plugins/<namespace>/index.js` that
+   * `registerPluginsFromEntry` loads and returns the exported `reconciler`
+   * value if it is a non-null object with `prepare` and `resolveFailure`
+   * methods. Returns `undefined` when no reconciler is exported or the
+   * namespace set is empty.
+   *
+   * The dynamic import hits Node's module cache (same specifier as
+   * `registerPluginsFromEntry`), so no second network/disk load occurs.
+   *
+   * @param entryDag  - The orchestration DAG whose placements drive namespace discovery.
+   * @param configDir - Absolute path to the directory that contains `plugins/`.
+   * @returns The first plugin reconciler found, or `undefined`.
+   */
+  static async resolveReconciler(
+    entryDag:  DAGType,
+    configDir: string,
+  ): Promise<ReconcilerInterface | undefined> {
+    const namespaces = PluginLoader.extractNamespaces(entryDag);
+    for (const namespace of namespaces) {
+      const entryPath = resolve(configDir, `plugins/${namespace}/index.js`);
+      let mod: unknown;
+      try {
+        mod = await import(entryPath);
+      } catch {
+        // Module not found or load failure — skip; registerPluginsFromEntry
+        // will surface the error with a clearer message.
+        continue;
+      }
+      const modRecord = mod as Record<string, unknown>;
+      const candidate = modRecord['reconciler'];
+      if (
+        candidate !== null &&
+        candidate !== undefined &&
+        typeof candidate === 'object' &&
+        typeof (candidate as Record<string, unknown>)['prepare'] === 'function' &&
+        typeof (candidate as Record<string, unknown>)['resolveFailure'] === 'function'
+      ) {
+        return candidate as ReconcilerInterface;
+      }
+    }
+    return undefined;
+  }
+
+  static async registerPluginsFromEntry(
+    dispatcher:    RipperDagonizer<ScrapeState>,
+    entryDag:      DAGType,
+    configDir:     string,
+  ): Promise<Set<string>> {
+    const namespaces = PluginLoader.extractNamespaces(entryDag);
 
     const loaded = new Set<string>();
     for (const namespace of namespaces) {

--- a/src/run/runDag.ts
+++ b/src/run/runDag.ts
@@ -244,7 +244,7 @@ export async function runDag(opts: RunDagOptionsType): Promise<void> {
       },
     }),
     ...(workerContainer !== undefined
-      ? { containers: { worker: workerContainer as unknown as DagContainerInterface<ScrapeState> } }
+      ? { containers: { worker: workerContainer as unknown as DagContainerInterface } }
       : {}),
   });
 
@@ -287,6 +287,15 @@ export async function runDag(opts: RunDagOptionsType): Promise<void> {
   PluginLoader.registerBuiltinNodes(dispatcher);
   await PluginLoader.registerPluginsFromEntry(dispatcher, dag, configDir);
   dispatcher.registerDAG(dag);
+
+  // ── Resolve plugin reconciler and patch services ──────────────────────────
+  // The plugin is now loaded (module cached), so this dynamic import is cheap.
+  // If the plugin exports `reconciler`, patch `holder.current` with it so
+  // `reconcile:identity` picks it up when it runs.
+  const pluginReconciler = await PluginLoader.resolveReconciler(dag, configDir);
+  if (pluginReconciler !== undefined) {
+    holder.current = { ...services, reconciler: pluginReconciler };
+  }
 
   // ── Seed initial state ────────────────────────────────────────────────────
   // When the run state declares an explicit `urls` list, seed `scrapeState.urls`

--- a/src/services/RipperServices.ts
+++ b/src/services/RipperServices.ts
@@ -21,6 +21,9 @@ import type { RateLimiter }       from '../modules/http/rateLimiter.js';
 import type { HttpRetryPolicy }   from '../modules/http/httpRetryPolicy.js';
 import type { ScrapeState }       from '../state/ScrapeState.js';
 import type { RunCrawlerType }    from '../types/RunState.js';
+import type { FailurePolicyInterface } from '../resilience/FailurePolicy.js';
+import type { ReconcilerInterface }    from '../resilience/Reconciler.js';
+import type { ResolveConfigType }      from '../types/LinkResolve.js';
 
 /**
  * Shared services injected into every node via `context.services`.
@@ -88,6 +91,21 @@ export type RipperServices = {
    * absent), it is split per record into a per-plugin subfolder.
    */
   readonly splitByTaskName?: boolean | undefined;
+  /**
+   * Failure policy for classifying and routing node failures.
+   * When absent, `DefaultFailurePolicy` (retryable→retry up to 2x, else→capture) is used.
+   */
+  readonly failurePolicy?: FailurePolicyInterface | undefined;
+  /**
+   * Identity reconciler for the post-crawl `reconcile:identity` phase.
+   * When absent, `DefaultReconciler` (all failures → `missing`) is used.
+   */
+  readonly reconciler?: ReconcilerInterface | undefined;
+  /**
+   * Link-resolution config for the opt-in `resolve:link` node.
+   * When absent, `resolve:link` routes immediately to `unresolved`.
+   */
+  readonly resolve?: ResolveConfigType | undefined;
   /**
    * Dispatcher reference for nodes that need to run child DAGs. Set to the
    * same dispatcher this services bag is registered on so nodes can call

--- a/src/types/FailurePolicy.ts
+++ b/src/types/FailurePolicy.ts
@@ -1,0 +1,46 @@
+/**
+ * Failure policy type contracts.
+ *
+ * These types flow between the failing node (`html:fetch`) and the routing
+ * node (`route:failure`), and are also consumed by `FailurePolicyInterface`
+ * implementors.
+ *
+ * @module types/FailurePolicy
+ * @since 3.2.0
+ */
+
+/**
+ * Context describing a node failure, written to state metadata under
+ * `LAST_FAILURE_KEY` by the failing node so `route:failure` can classify it.
+ *
+ * @category Resilience
+ * @since 3.2.0
+ */
+export type FailureContextType = {
+  /** The URL that was being fetched when the failure occurred. */
+  readonly url: string;
+  /** HTTP response status code, if the failure was an HTTP error. */
+  readonly status: number | undefined;
+  /** Whether the failure is considered transient and safe to retry. */
+  readonly retryable: boolean;
+  /** 1-based attempt number, incremented by `route:failure` before classification. */
+  readonly attempt: number;
+  /** Pipeline phase that produced the failure. */
+  readonly phase: 'fetch' | 'parse';
+  /** Link text associated with the URL, if available from a crawl context. */
+  readonly linkText: string | undefined;
+};
+
+/**
+ * Decision returned by a failure policy's `classify` method.
+ *
+ * The discriminant field `route` drives which output port `route:failure` emits.
+ *
+ * @category Resilience
+ * @since 3.2.0
+ */
+export type FailureRouteType =
+  | { readonly route: 'retry' }
+  | { readonly route: 'resolve'; readonly strategies: readonly string[] }
+  | { readonly route: 'capture' }
+  | { readonly route: 'expected'; readonly reason: string };

--- a/src/types/LinkResolve.ts
+++ b/src/types/LinkResolve.ts
@@ -1,0 +1,35 @@
+/**
+ * Link-resolution config type.
+ *
+ * Placed in `services.resolve` to enable the `resolve:link` node.
+ * When absent, `resolve:link` routes immediately to `unresolved`.
+ *
+ * @module types/LinkResolve
+ * @since 3.2.0
+ */
+
+/**
+ * Configuration for the opt-in `resolve:link` node.
+ *
+ * @category Resilience
+ * @since 3.2.0
+ */
+export type ResolveConfigType = {
+  /** Ordered strategy names to attempt (e.g. `['crossLocator', 'canonical']`). */
+  readonly strategies: readonly string[];
+  /**
+   * Category names for the `crossLocator` strategy.
+   * Each non-failed category is tried with the same numeric ID from the failed url.
+   */
+  readonly categorySet?: readonly string[] | undefined;
+  /**
+   * URL template for the `search` strategy; `{q}` is replaced with the
+   * URL-encoded link text from the failure context.
+   */
+  readonly searchUrl?: string | undefined;
+  /**
+   * Maximum resolve attempts per page before the node gives up (`unresolved`).
+   * Defaults to `2` when absent.
+   */
+  readonly budget?: number | undefined;
+};

--- a/src/types/Reconciler.ts
+++ b/src/types/Reconciler.ts
@@ -1,0 +1,87 @@
+/**
+ * Reconciler type contracts.
+ *
+ * These types flow between `reconcile:identity` (which builds the index and
+ * runs resolution) and `report:crawl-health` (which consumes the summary).
+ * Plugin implementors of {@link ReconcilerInterface} depend on these types.
+ *
+ * @module types/Reconciler
+ * @since 3.2.0
+ */
+
+/**
+ * Resolution decision for a captured failure.
+ *
+ * The discriminant field `status` identifies which case applied:
+ * - `capturedElsewhere` — the concept was successfully scraped at a different
+ *   URL; the dead link is harmless.
+ * - `missing`           — no concept matching this failure was found anywhere
+ *   in the captured output; data may be absent.
+ * - `dead`              — the resource is known to not exist (lore-only, etc.);
+ *   the failure is expected and should not count against completeness.
+ *
+ * @category Resilience
+ * @since 3.2.0
+ */
+export type ResolutionType =
+  | { readonly status: 'capturedElsewhere'; readonly at: string }
+  | { readonly status: 'missing' }
+  | { readonly status: 'dead'; readonly reason: string };
+
+/**
+ * A captured failure document as passed to
+ * {@link ReconcilerInterface.resolveFailure}.
+ *
+ * Mirrors the subset of an `error:capture` output doc that identity matching
+ * needs; the full doc on disk may contain additional fields.
+ *
+ * @category Resilience
+ * @since 3.2.0
+ */
+export type CapturedFailureType = {
+  readonly url: string;
+  readonly errors: readonly {
+    readonly code: string;
+    readonly message: string;
+    readonly operation: string;
+  }[];
+};
+
+/**
+ * A successfully scraped concept document as passed to
+ * {@link ReconcilerInterface.prepare}.
+ *
+ * The plugin controls the full index shape — this type carries just the
+ * raw URL and parsed output so the plugin can extract whatever identity
+ * keys it needs.
+ *
+ * @category Resilience
+ * @since 3.3.0
+ */
+export type CapturedConceptType = {
+  readonly url: string;
+  readonly output: Record<string, unknown>;
+};
+
+/**
+ * Aggregated reconciliation summary produced by `reconcile:identity` and
+ * consumed by `report:crawl-health`.
+ *
+ * @category Resilience
+ * @since 3.2.0
+ */
+export type ReconciliationSummaryType = {
+  readonly totals: {
+    readonly concepts: number;
+    readonly failures: number;
+    readonly capturedElsewhere: number;
+    readonly missing: number;
+    readonly dead: number;
+  };
+  readonly capturedElsewhere: readonly { readonly url: string; readonly at: string }[];
+  readonly missing: readonly {
+    readonly url: string;
+    readonly errors: readonly { readonly code: string; readonly message: string }[];
+  }[];
+  readonly dead: readonly { readonly url: string; readonly reason: string }[];
+};

--- a/tests/e2e/docs-html.test.ts
+++ b/tests/e2e/docs-html.test.ts
@@ -18,6 +18,7 @@ import { spawnSync } from 'node:child_process';
 import { HtmlScraper }   from '../../src/scrapers/HtmlScraper.js';
 import { ScrapeState }   from '../../src/state/ScrapeState.js';
 import { Dagonizer }     from '@studnicky/dagonizer';
+import { NodeContextBuilder } from '@studnicky/dagonizer/entities';
 import { Logger }        from '../../src/modules/logger/logger.js';
 import type { RipperServices } from '../../src/services/RipperServices.js';
 
@@ -117,13 +118,12 @@ describe('docs-html e2e — HTML scraper against built Ripperoni docs', () => {
     state.page  = { targetId: 'ripperoni-docs', title: 'Architecture', url: page.url, html: page.html };
 
     // Run the node directly (no DAG needed for a single-node test).
-    const ctx = {
+    const ctx = NodeContextBuilder.of<RipperServices>(
+      'test',
+      'docs:parse',
+      new AbortController().signal,
       services,
-      signal:   new AbortController().signal,
-      dagName:  'test',
-      nodeName: 'docs:parse',
-      runId:    'test',
-    };
+    );
     await docsParseNode.execute(Batch.of(state), ctx);
 
     const sections = state.getMetadata<DocsSectionOutput[]>('sections');

--- a/tests/e2e/wiki-docs.test.ts
+++ b/tests/e2e/wiki-docs.test.ts
@@ -14,6 +14,7 @@ import { fileURLToPath } from 'node:url';
 
 import { MediaWikiScraper }   from '../../src/scrapers/MediaWikiScraper.js';
 import { ScrapeState }        from '../../src/state/ScrapeState.js';
+import { NodeContextBuilder } from '@studnicky/dagonizer/entities';
 import type { RipperServices } from '../../src/services/RipperServices.js';
 import type { WikiFixtureServerInterface } from './fixtures/wiki/server.js';
 import { startWikiFixtureServer } from './fixtures/wiki/server.js';
@@ -77,13 +78,12 @@ describe('wiki-docs e2e — MediaWiki scraper against fixture server', () => {
 
     const { wikiDocsParseNode } = await import('../../examples/wiki-docs/plugin.js');
 
-    const ctx = {
-      services: {} as unknown as RipperServices,
-      signal:   new AbortController().signal,
-      dagName:  'test',
-      nodeName: 'wiki-docs:parse',
-      runId:    'test',
-    };
+    const ctx = NodeContextBuilder.of<RipperServices>(
+      'test',
+      'wiki-docs:parse',
+      new AbortController().signal,
+      {} as unknown as RipperServices,
+    );
 
     const outputs: RipperoniComponentOutput[] = [];
 
@@ -126,13 +126,12 @@ describe('wiki-docs e2e — MediaWiki scraper against fixture server', () => {
 
     const { wikiDocsParseNode } = await import('../../examples/wiki-docs/plugin.js');
 
-    const ctx = {
-      services: {} as unknown as RipperServices,
-      signal:   new AbortController().signal,
-      dagName:  'test',
-      nodeName: 'wiki-docs:parse',
-      runId:    'test',
-    };
+    const ctx = NodeContextBuilder.of<RipperServices>(
+      'test',
+      'wiki-docs:parse',
+      new AbortController().signal,
+      {} as unknown as RipperServices,
+    );
 
     for (const page of pages) {
       const state = new ScrapeState();

--- a/tests/integration/crawl-embedded.test.ts
+++ b/tests/integration/crawl-embedded.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 
 import { DAGDocument, Timeout } from '@studnicky/dagonizer';
-import type { Batch } from '@studnicky/dagonizer';
+import type { Batch, SchemaObjectType } from '@studnicky/dagonizer';
 import { RipperDagonizer }             from '../../src/dispatcher/RipperDagonizer.js';
 import { ScrapeState }         from '../../src/state/ScrapeState.js';
 import { PluginLoader }        from '../../src/run/PluginLoader.js';
@@ -263,9 +263,10 @@ describe('crawl-embedded integration', () => {
 
     // Stub node: records currentUrl in processedUrls, routes 'success'.
     const stubRecordNode = {
-      name:    'stub:record',
-      outputs: ['success'] as ['success'],
-      timeout: Timeout.none(),
+      name:         'stub:record',
+      outputs:      ['success'] as ['success'],
+      timeout:      Timeout.none(),
+      outputSchema: { success: { type: 'object' } } as Record<'success', SchemaObjectType>,
       async execute(batch: Batch<ScrapeState>) {
         for (const { state } of batch) {
           processedUrls.push(state.page.url);
@@ -351,9 +352,10 @@ describe('crawl-embedded integration', () => {
     });
 
     const stubRecordNode = {
-      name:    'stub:record',
-      outputs: ['success'] as ['success'],
-      timeout: Timeout.none(),
+      name:         'stub:record',
+      outputs:      ['success'] as ['success'],
+      timeout:      Timeout.none(),
+      outputSchema: { success: { type: 'object' } } as Record<'success', SchemaObjectType>,
       async execute(batch: Batch<ScrapeState>) {
         const { RoutedBatchBuilder } = await import('@studnicky/dagonizer');
         return RoutedBatchBuilder.of('success', batch);

--- a/tests/integration/rawContent.test.ts
+++ b/tests/integration/rawContent.test.ts
@@ -334,6 +334,15 @@ import { RoutedBatchBuilder, Timeout } from ${JSON.stringify(`file://${dagonzerI
 const stubParseNode = {
   name:    'stub:parse',
   outputs: ['success'],
+  outputSchema: {
+    success: {
+      type: 'object',
+      properties: {
+        output: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] },
+      },
+      required: ['output'],
+    },
+  },
   timeout: Timeout.none(),
   async execute(batch) {
     for (const { state } of batch) {

--- a/tests/integration/worker-container.test.ts
+++ b/tests/integration/worker-container.test.ts
@@ -46,7 +46,7 @@ import { dirname }         from 'node:path';
 import { fileURLToPath }   from 'node:url';
 
 import { DAGBuilder, Dagonizer, NodeStateBase, Timeout, RoutedBatchBuilder } from '@studnicky/dagonizer';
-import type { NodeInterface }                    from '@studnicky/dagonizer/contracts';
+import type { NodeInterface, SchemaObjectType }  from '@studnicky/dagonizer/contracts';
 import type { DagContainerInterface }            from '@studnicky/dagonizer';
 import type { JsonObjectType }                   from '@studnicky/dagonizer/entities';
 import { RecommendedWorkerCountConfigDefault }  from '@studnicky/dagonizer/entities';
@@ -108,9 +108,10 @@ class TestState extends NodeStateBase {
 // { processedInWorker: false } so assertions can confirm which path ran.
 
 const stubCaptureNode: NodeInterface<TestState, string, Record<string, never>> = {
-  name:    'stub:capture',
-  outputs: ['done'],
-  timeout: Timeout.none(),
+  name:         'stub:capture',
+  outputs:      ['done'],
+  timeout:      Timeout.none(),
+  outputSchema: { done: { type: 'object' } } as Record<string, SchemaObjectType>,
   async execute(batch) {
     for (const { state } of batch) {
       state.output = { processedInWorker: false };
@@ -236,7 +237,7 @@ describe('worker-container integration', () => {
 
     const dispatcher = new Dagonizer<TestState, Record<string, never>>({
       services:   {},
-      containers: { worker: container as unknown as DagContainerInterface<TestState> },
+      containers: { worker: container as unknown as DagContainerInterface },
     });
     // Register test:stub-page on coordinator (satisfies validator).
     // Execution is routed to the worker which uses StubRegistryModule's version.
@@ -323,7 +324,7 @@ describe('worker-container integration', () => {
 
     const workerDispatcher = new Dagonizer<TestState, Record<string, never>>({
       services:   {},
-      containers: { worker: container as unknown as DagContainerInterface<TestState> },
+      containers: { worker: container as unknown as DagContainerInterface },
     });
     workerDispatcher.registerNode(stubCaptureNode);
     workerDispatcher.registerDAG(inProcessPageDag);   // satisfies validator

--- a/tests/unit/dispatcher/RipperDagonizer.test.ts
+++ b/tests/unit/dispatcher/RipperDagonizer.test.ts
@@ -9,7 +9,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { NodeStateBase, DAGBuilder, RoutedBatchBuilder, Timeout } from '@studnicky/dagonizer';
-import type { NodeInterface, NodeContextType, RoutedBatchType, ExecutionResultType , Batch} from '@studnicky/dagonizer';
+import type { NodeInterface, NodeContextType, RoutedBatchType, ExecutionResultType, Batch, SchemaObjectType } from '@studnicky/dagonizer';
 
 import { RipperDagonizer } from '../../../src/dispatcher/RipperDagonizer.js';
 import { Logger }          from '../../../src/modules/logger/logger.js';
@@ -37,6 +37,7 @@ const noopNode: NodeInterface<MinimalState, 'done', RipperServices> = {
   name:     TEST_NODE_NAME,
   outputs:  ['done'],
   timeout:  Timeout.none(),
+  outputSchema: { done: { type: 'object' } } as Record<'done', SchemaObjectType>,
   async execute(
     batch:    Batch<MinimalState>,
     _context: NodeContextType<RipperServices>,

--- a/tests/unit/nodes/crawl/helpers.ts
+++ b/tests/unit/nodes/crawl/helpers.ts
@@ -1,6 +1,7 @@
 /**
  * Shared test helpers for crawl node unit tests.
  */
+import { NodeContextBuilder } from '@studnicky/dagonizer/entities';
 import type { NodeContextType } from '@studnicky/dagonizer';
 
 import { ScrapeState }         from '../../../../src/state/ScrapeState.js';
@@ -30,11 +31,11 @@ export const makeTestContext = (
       }
     : undefined;
 
-  return {
-    dagName:  'test',
-    nodeName: 'test',
-    signal:   new AbortController().signal,
-    services: {
+  return NodeContextBuilder.of<RipperServices>(
+    'test',
+    'test',
+    new AbortController().signal,
+    {
       log: {
         debug: () => {},
         info:  () => {},
@@ -48,8 +49,8 @@ export const makeTestContext = (
       ...(crawlerBlock !== undefined ? { crawler: crawlerBlock } : {}),
       ...(limiter !== undefined ? { crawlLimiter: limiter } : {}),
       ...(policy  !== undefined ? { crawlPolicy:  policy  } : {}),
-    },
-  };
+    } as unknown as RipperServices,
+  );
 };
 
 /**

--- a/tests/unit/nodes/reconcile-identity.test.ts
+++ b/tests/unit/nodes/reconcile-identity.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for ReconcileIdentityNode and ReportCrawlHealthNode.
+ */
+import { describe, it, before, after } from 'node:test';
+import { mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import assert from 'node:assert/strict';
+
+import { Batch }               from '@studnicky/dagonizer';
+import { NodeContextBuilder }  from '@studnicky/dagonizer/entities';
+
+import { ScrapeState }              from '../../../src/state/ScrapeState.js';
+import { ReconcileIdentityNode }    from '../../../src/nodes/ReconcileIdentityNode.js';
+import { ReportCrawlHealthNode }    from '../../../src/nodes/ReportCrawlHealthNode.js';
+import { RECONCILIATION_KEY }       from '../../../src/resilience/Reconciler.js';
+import type { ReconcilerInterface } from '../../../src/resilience/Reconciler.js';
+import type {
+  CapturedConceptType,
+  CapturedFailureType,
+  ReconciliationSummaryType,
+  ResolutionType,
+} from '../../../src/types/Reconciler.js';
+import type { RipperServices }      from '../../../src/services/RipperServices.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const TARGET_ID      = 'test:crawl';
+const PLUGIN_TASK    = 'test:page';
+const BASE_OUT       = join('/tmp', `ripper-reconcile-test-${Date.now()}`);
+const DOCS_DIR       = join(BASE_OUT, TARGET_ID, PLUGIN_TASK);
+
+/** Build a minimal NodeContext with the given services overrides. */
+const makeContext = (
+  overrides: Partial<RipperServices> = {},
+): ReturnType<typeof NodeContextBuilder.of<RipperServices>> =>
+  NodeContextBuilder.of<RipperServices>(
+    'test',
+    'test',
+    new AbortController().signal,
+    {
+      log: {
+        debug: () => {},
+        info:  () => {},
+        warn:  () => {},
+        error: () => {},
+      } as unknown as RipperServices['log'],
+      cache:          null,
+      target:         { id: TARGET_ID },
+      outDir:         BASE_OUT,
+      pluginTaskName: PLUGIN_TASK,
+      dispatcher:     {} as RipperServices['dispatcher'],
+      ...overrides,
+    } as unknown as RipperServices,
+  );
+
+/** Write a concept doc to the temp dir. */
+const writeConceptDoc = (slug: string, doc: Record<string, unknown>): string => {
+  const filePath = join(DOCS_DIR, `${slug}.json`);
+  writeFileSync(filePath, JSON.stringify(doc), 'utf-8');
+  return filePath;
+};
+
+/** Write an error doc to the temp dir. */
+const writeErrorDoc = (slug: string, doc: Record<string, unknown>): string => {
+  const filePath = join(DOCS_DIR, `${slug}.json`);
+  writeFileSync(filePath, JSON.stringify({ _type: 'error', ...doc }), 'utf-8');
+  return filePath;
+};
+
+// ── Stub reconciler ────────────────────────────────────────────────────────────
+
+type StubIndex = ReadonlyMap<string, string>; // name → url
+
+/**
+ * Test reconciler: indexes on `output.name`; resolves a failure whose first
+ * error message matches a known name to the URL where that name was captured.
+ */
+class StubReconciler implements ReconcilerInterface<StubIndex> {
+  public prepare(concepts: readonly CapturedConceptType[]): StubIndex {
+    const map = new Map<string, string>();
+    for (const concept of concepts) {
+      const name = concept.output['name'];
+      if (typeof name === 'string') map.set(name, concept.url);
+    }
+    return map;
+  }
+
+  public resolveFailure(
+    failure: CapturedFailureType,
+    index: StubIndex,
+  ): ResolutionType {
+    // Use the first error's message as "link text" for test matching.
+    const linkText = failure.errors[0]?.message ?? '';
+    const at = index.get(linkText);
+    if (at !== undefined) return { status: 'capturedElsewhere', at };
+    return { status: 'missing' };
+  }
+}
+
+// ── Setup / teardown ───────────────────────────────────────────────────────────
+
+before(() => {
+  mkdirSync(DOCS_DIR, { recursive: true });
+});
+
+after(() => {
+  rmSync(BASE_OUT, { recursive: true, force: true });
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ReconcileIdentityNode — stub reconciler', () => {
+  it('routes done', async () => {
+    // Two concept docs and one error doc that resolves capturedElsewhere.
+    writeConceptDoc('catfolk', { url: 'https://example.com/Ancestries/3', name: 'Catfolk' });
+    writeConceptDoc('goblin',  { url: 'https://example.com/Ancestries/4', name: 'Goblin' });
+    writeErrorDoc('missing-catfolk', {
+      url:    'https://example.com/Classes/3',
+      errors: [{ code: 'fetchFailed', message: 'Catfolk', operation: 'html:fetch', context: {} }],
+    });
+
+    const state  = new ScrapeState();
+    const result = await ReconcileIdentityNode.execute(
+      Batch.of(state),
+      makeContext({ reconciler: new StubReconciler() }),
+    );
+    assert.ok(result.has('done'));
+  });
+
+  it('error doc gains resolution: capturedElsewhere when name matches', async () => {
+    const errorFile = join(DOCS_DIR, 'missing-catfolk.json');
+    const onDisk = JSON.parse(readFileSync(errorFile, 'utf-8')) as Record<string, unknown>;
+
+    assert.ok('resolution' in onDisk, 'resolution field should be written to error doc');
+    const res = onDisk['resolution'] as { status: string; at?: string };
+    assert.equal(res.status, 'capturedElsewhere');
+    assert.equal(res.at, 'https://example.com/Ancestries/3');
+  });
+
+  it('summary metadata has correct totals', async () => {
+    const state = new ScrapeState();
+    // Re-run so the state has a fresh metadata snapshot.
+    await ReconcileIdentityNode.execute(
+      Batch.of(state),
+      makeContext({ reconciler: new StubReconciler() }),
+    );
+
+    const summary = state.getMetadata<ReconciliationSummaryType>(RECONCILIATION_KEY);
+    assert.ok(summary !== undefined, 'summary should be set in metadata');
+    assert.equal(summary.totals.concepts,          2);
+    assert.equal(summary.totals.failures,          1);
+    assert.equal(summary.totals.capturedElsewhere, 1);
+    assert.equal(summary.totals.missing,           0);
+    assert.equal(summary.totals.dead,              0);
+    assert.equal(summary.capturedElsewhere.length, 1);
+    assert.equal(summary.capturedElsewhere[0]?.url, 'https://example.com/Classes/3');
+    assert.equal(summary.capturedElsewhere[0]?.at,  'https://example.com/Ancestries/3');
+  });
+});
+
+describe('ReconcileIdentityNode — default reconciler', () => {
+  it('classifies all failures as missing with default reconciler', async () => {
+    // Add a second error doc for this sub-suite.
+    writeErrorDoc('missing-goblin', {
+      url:    'https://example.com/Classes/4',
+      errors: [{ code: 'fetchFailed', message: 'Goblin', operation: 'html:fetch', context: {} }],
+    });
+
+    const state = new ScrapeState();
+    // No reconciler → uses DefaultReconciler → all missing.
+    await ReconcileIdentityNode.execute(Batch.of(state), makeContext());
+
+    const summary = state.getMetadata<ReconciliationSummaryType>(RECONCILIATION_KEY);
+    assert.ok(summary !== undefined);
+    assert.equal(summary.totals.capturedElsewhere, 0);
+    assert.equal(summary.totals.missing,           summary.totals.failures);
+    assert.equal(summary.totals.dead,              0);
+  });
+});
+
+describe('ReconcileIdentityNode — empty directory', () => {
+  it('handles missing docs directory gracefully', async () => {
+    const state = new ScrapeState();
+    const emptyCtx = makeContext({
+      target:         { id: 'nonexistent:crawl' },
+      pluginTaskName: 'nonexistent:page',
+    });
+    const result = await ReconcileIdentityNode.execute(Batch.of(state), emptyCtx);
+    assert.ok(result.has('done'));
+
+    const summary = state.getMetadata<ReconciliationSummaryType>(RECONCILIATION_KEY);
+    assert.ok(summary !== undefined);
+    assert.equal(summary.totals.concepts,  0);
+    assert.equal(summary.totals.failures,  0);
+  });
+});
+
+describe('ReportCrawlHealthNode', () => {
+  it('writes crawl-health.json with correct structure', async () => {
+    // Prime state with a known summary.
+    const summary: ReconciliationSummaryType = {
+      totals: { concepts: 5, failures: 2, capturedElsewhere: 1, missing: 1, dead: 0 },
+      capturedElsewhere: [{ url: 'https://example.com/a', at: 'https://example.com/b' }],
+      missing:  [{ url: 'https://example.com/c', errors: [{ code: 'err', message: 'msg' }] }],
+      dead: [],
+    };
+
+    const state = new ScrapeState();
+    state.setMetadata(RECONCILIATION_KEY, summary);
+
+    const result = await ReportCrawlHealthNode.execute(Batch.of(state), makeContext());
+    assert.ok(result.has('done'));
+
+    const reportPath = join(BASE_OUT, TARGET_ID, 'crawl-health.json');
+    const report = JSON.parse(readFileSync(reportPath, 'utf-8')) as Record<string, unknown>;
+
+    assert.equal(report['target'], TARGET_ID);
+    assert.ok(typeof report['generatedAt'] === 'string');
+    const totals = report['totals'] as Record<string, number>;
+    assert.equal(totals['concepts'],          5);
+    assert.equal(totals['capturedElsewhere'], 1);
+    assert.equal(totals['missing'],           1);
+    assert.equal(totals['dead'],              0);
+  });
+
+  it('writes zero-totals report when no summary is present', async () => {
+    const state = new ScrapeState();
+    // No RECONCILIATION_KEY set → report:crawl-health falls back to zero totals.
+
+    await ReportCrawlHealthNode.execute(Batch.of(state), makeContext());
+
+    const reportPath = join(BASE_OUT, TARGET_ID, 'crawl-health.json');
+    const report = JSON.parse(readFileSync(reportPath, 'utf-8')) as Record<string, unknown>;
+    const totals = report['totals'] as Record<string, number>;
+    assert.equal(totals['concepts'],  0);
+    assert.equal(totals['failures'],  0);
+    assert.equal(totals['missing'],   0);
+  });
+});

--- a/tests/unit/nodes/resolve-link.test.ts
+++ b/tests/unit/nodes/resolve-link.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for ResolveLinkNode.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Batch }              from '@studnicky/dagonizer';
+import { NodeContextBuilder } from '@studnicky/dagonizer/entities';
+
+import { ScrapeState }      from '../../../src/state/ScrapeState.js';
+import { ResolveLinkNode }  from '../../../src/nodes/ResolveLinkNode.js';
+import { LAST_FAILURE_KEY } from '../../../src/resilience/FailurePolicy.js';
+import type { FailureContextType } from '../../../src/resilience/FailurePolicy.js';
+import type { RipperServices }     from '../../../src/services/RipperServices.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const FAILED_URL    = 'https://aonprd.com/Monsters.aspx?ID=77';
+const CORRECTED_URL = 'https://aonprd.com/Classes.aspx?ID=77';
+
+const GOOD_CATEGORY = 'Classes';
+
+/**
+ * Minimal stub: resolves for `GOOD_CATEGORY`, throws for all others.
+ */
+class StubHtmlScraper {
+  public async fetchPage(url: string): Promise<{ url: string; html: string; $: unknown }> {
+    if (url.includes(`/${GOOD_CATEGORY}.aspx`)) {
+      return { url, html: '<html></html>', $: {} };
+    }
+    throw new Error(`fetch failed for ${url}`);
+  }
+}
+
+/** Build a minimal NodeContext for ResolveLinkNode tests. */
+const makeContext = (overrides: Partial<RipperServices> = {}) =>
+  NodeContextBuilder.of<RipperServices>(
+    'test',
+    'test',
+    new AbortController().signal,
+    {
+      log: {
+        debug: () => {},
+        info:  () => {},
+        warn:  () => {},
+        error: () => {},
+      } as unknown as RipperServices['log'],
+      cache:      null,
+      target:     { id: 'test' },
+      outDir:     '/tmp',
+      dispatcher: {} as RipperServices['dispatcher'],
+      ...overrides,
+    } as unknown as RipperServices,
+  );
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('ResolveLinkNode — happy path', () => {
+  it('routes resolved and stashes corrected url in metadata', async () => {
+    const state = new ScrapeState();
+    state.page  = { targetId: 'test', title: '', url: FAILED_URL };
+
+    const failure: FailureContextType = {
+      url:       FAILED_URL,
+      status:    404,
+      retryable: false,
+      attempt:   1,
+      phase:     'fetch',
+      linkText:  undefined,
+    };
+    state.setMetadata(LAST_FAILURE_KEY, failure);
+
+    const context = makeContext({
+      htmlScraper: new StubHtmlScraper() as unknown as RipperServices['htmlScraper'],
+      resolve: {
+        strategies:  ['crossLocator'],
+        categorySet: ['Ancestries', 'Classes', 'NPCs'],
+      },
+    });
+
+    const result = await ResolveLinkNode.execute(Batch.of(state), context);
+
+    assert.ok(result.has('resolved'), `expected 'resolved', got ${[...result.keys()].join(', ')}`);
+    assert.equal(state.getMetadata<string>('currentUrl'), CORRECTED_URL);
+  });
+});
+
+describe('ResolveLinkNode — no strategies', () => {
+  it('routes unresolved when strategies array is empty', async () => {
+    const state = new ScrapeState();
+    state.page  = { targetId: 'test', title: '', url: FAILED_URL };
+
+    const context = makeContext({
+      resolve: { strategies: [] },
+    });
+
+    const result = await ResolveLinkNode.execute(Batch.of(state), context);
+
+    assert.ok(result.has('unresolved'));
+  });
+});
+
+describe('ResolveLinkNode — budget exhaustion', () => {
+  it('routes unresolved after resolve budget (budget=1) is exceeded on 2nd call', async () => {
+    // Call 1: succeeds (attempt=1 <= budget=1) → resolved.
+    const state1 = new ScrapeState();
+    state1.page  = { targetId: 'test', title: '', url: FAILED_URL };
+
+    const failure: FailureContextType = {
+      url:       FAILED_URL,
+      status:    404,
+      retryable: false,
+      attempt:   1,
+      phase:     'fetch',
+      linkText:  undefined,
+    };
+    state1.setMetadata(LAST_FAILURE_KEY, failure);
+
+    const context = makeContext({
+      htmlScraper: new StubHtmlScraper() as unknown as RipperServices['htmlScraper'],
+      resolve: {
+        strategies:  ['crossLocator'],
+        categorySet: ['Ancestries', 'Classes', 'NPCs'],
+        budget:      1,
+      },
+    });
+
+    const result1 = await ResolveLinkNode.execute(Batch.of(state1), context);
+    assert.ok(result1.has('resolved'), 'first call within budget should resolve');
+
+    // Call 2 on the same state: attempt becomes 2 > budget=1 → unresolved.
+    state1.setMetadata(LAST_FAILURE_KEY, failure);
+    const result2 = await ResolveLinkNode.execute(Batch.of(state1), context);
+    assert.ok(result2.has('unresolved'), 'second call over budget should be unresolved');
+  });
+});

--- a/tests/unit/nodes/wiki/ChooseModeNode.test.ts
+++ b/tests/unit/nodes/wiki/ChooseModeNode.test.ts
@@ -5,7 +5,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { Dagonizer, DAGBuilder, RoutedBatchBuilder, Timeout } from '@studnicky/dagonizer';
-import type { NodeInterface, NodeContextType, RoutedBatchType , Batch} from '@studnicky/dagonizer';
+import type { NodeInterface, NodeContextType, RoutedBatchType, Batch, SchemaObjectType } from '@studnicky/dagonizer';
 
 import { MemberResolutionState } from '../../../../src/state/MemberResolutionState.js';
 import { ChooseModeNode }        from '../../../../src/nodes/wiki/ChooseModeNode.js';
@@ -33,6 +33,7 @@ const runChooseMode = async (state: MemberResolutionState): Promise<ModePort[]> 
     name:     `stub:cm:${port}` as string,
     outputs:  ['ok'] as const,
     timeout:  Timeout.none(),
+    outputSchema: { ok: { type: 'object' } } as Record<'ok', SchemaObjectType>,
     async execute(
       batch:    Batch<MemberResolutionState>,
       _context: NodeContextType<RipperServices>,

--- a/tests/unit/plugins/aonprd/contract-validator.test.ts
+++ b/tests/unit/plugins/aonprd/contract-validator.test.ts
@@ -9,7 +9,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import type { NodeInterface, NodeContextType, Batch } from '@studnicky/dagonizer';
+import type { NodeInterface, NodeContextType, Batch, SchemaObjectType } from '@studnicky/dagonizer';
 import { DAGBuilder, DAGError, RoutedBatchBuilder, Timeout } from '@studnicky/dagonizer';
 
 import { RipperDagonizer } from '../../../../src/dispatcher/RipperDagonizer.js';
@@ -42,9 +42,10 @@ describe('ContractRegistryValidator integration', () => {
     // Build a minimal DAG that references 'broken:nodeB' which is NOT registered.
     // registerDAG must throw DAGError when it finds an unresolved placement.
     const nodeA: NodeInterface<ScrapeState, 'success', RipperServices> = {
-      name:     'broken:nodeA',
-      outputs:  ['success'] as const,
-      timeout:  Timeout.none(),
+      name:         'broken:nodeA',
+      outputs:      ['success'] as const,
+      timeout:      Timeout.none(),
+      outputSchema: { success: { type: 'object' } } as Record<'success', SchemaObjectType>,
       async execute(
         batch: Batch<ScrapeState>,
         _ctx:  NodeContextType<RipperServices>,
@@ -56,9 +57,10 @@ describe('ContractRegistryValidator integration', () => {
     const brokenDag = new DAGBuilder('broken-dag-1', '1.0')
       .node('broken:nodeA', nodeA, { success: 'broken:nodeB' })
       .node('broken:nodeB', {
-        name:    'broken:nodeB',
-        outputs: ['done'] as const,
-        timeout: Timeout.none(),
+        name:         'broken:nodeB',
+        outputs:      ['done'] as const,
+        timeout:      Timeout.none(),
+        outputSchema: { done: { type: 'object' } } as Record<'done', SchemaObjectType>,
         async execute(
           batch: Batch<ScrapeState>,
           _ctx:  NodeContextType<RipperServices>,
@@ -89,9 +91,10 @@ describe('ContractRegistryValidator integration', () => {
 
   it('DAG with no registered nodes at all throws DAGError at registerDAG', () => {
     const entryNode: NodeInterface<ScrapeState, 'success', RipperServices> = {
-      name:     'unregistered:entry',
-      outputs:  ['success'] as const,
-      timeout:  Timeout.none(),
+      name:         'unregistered:entry',
+      outputs:      ['success'] as const,
+      timeout:      Timeout.none(),
+      outputSchema: { success: { type: 'object' } } as Record<'success', SchemaObjectType>,
       async execute(
         batch: Batch<ScrapeState>,
         _ctx:  NodeContextType<RipperServices>,
@@ -101,9 +104,10 @@ describe('ContractRegistryValidator integration', () => {
     };
 
     const tailNode: NodeInterface<ScrapeState, 'success', RipperServices> = {
-      name:     'unregistered:tail',
-      outputs:  ['success'] as const,
-      timeout:  Timeout.none(),
+      name:         'unregistered:tail',
+      outputs:      ['success'] as const,
+      timeout:      Timeout.none(),
+      outputSchema: { success: { type: 'object' } } as Record<'success', SchemaObjectType>,
       async execute(
         batch: Batch<ScrapeState>,
         _ctx:  NodeContextType<RipperServices>,

--- a/tests/unit/plugins/aonprd/reconciler.test.ts
+++ b/tests/unit/plugins/aonprd/reconciler.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for AonprdReconciler.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { AonprdReconciler } from '../../../../plugins/aonprd/AonprdReconciler.js';
+import type { CapturedConceptType } from '../../../../src/resilience/Reconciler.js';
+
+class AonprdReconcilerTest {
+  static run(): void {
+    describe('AonprdReconciler', () => {
+      const reconciler = new AonprdReconciler();
+
+      it('resolves capturedElsewhere when link text matches a captured concept name', () => {
+        // "Catfolk" concept at Ancestries URL.
+        // Another concept whose links array contains a link to Classes/77 with text "catfolk".
+        const catfolkUrl = 'https://2e.aonprd.com/Ancestries.aspx?ID=77';
+        const concepts: CapturedConceptType[] = [
+          {
+            url:    catfolkUrl,
+            output: { name: 'Catfolk', links: [] },
+          },
+          {
+            url:    'https://2e.aonprd.com/Classes.aspx?ID=1',
+            output: {
+              name:  'SomeClass',
+              links: [
+                { href: 'Classes.aspx?ID=77', text: 'catfolk', kind: 'Classes', id: 77 },
+              ],
+            },
+          },
+        ];
+        const index  = reconciler.prepare(concepts);
+        const result = reconciler.resolveFailure(
+          { url: 'https://2e.aonprd.com/Classes.aspx?ID=77', errors: [] },
+          index,
+        );
+        assert.deepEqual(result, { status: 'capturedElsewhere', at: catfolkUrl });
+      });
+
+      it('resolves missing when link text matches no concept name', () => {
+        // "cythbikian" (the link text) ≠ "cythbikian staff" (the concept name, normalized)
+        const concepts: CapturedConceptType[] = [
+          {
+            url:    'https://2e.aonprd.com/Equipment.aspx?ID=3611',
+            output: {
+              name:  'Cythbikian Staff',
+              links: [
+                { href: 'Monsters.aspx?ID=3542', text: 'cythbikian', kind: 'Monsters', id: 3542 },
+              ],
+            },
+          },
+        ];
+        const index  = reconciler.prepare(concepts);
+        const result = reconciler.resolveFailure(
+          { url: 'https://2e.aonprd.com/Monsters.aspx?ID=3542', errors: [] },
+          index,
+        );
+        assert.deepEqual(result, { status: 'missing' });
+      });
+
+      it('handles full-url links in output.links (strips origin)', () => {
+        const ancestryUrl = 'https://2e.aonprd.com/Ancestries.aspx?ID=9';
+        const concepts: CapturedConceptType[] = [
+          { url: ancestryUrl, output: { name: 'Catfolk', links: [] } },
+          {
+            url:    'https://2e.aonprd.com/Classes.aspx?ID=1',
+            output: {
+              name:  'SomeClass',
+              // Link href is a full URL this time.
+              links: [
+                { href: 'https://2e.aonprd.com/Ancestries.aspx?ID=9', text: 'Catfolk', kind: 'Ancestries', id: 9 },
+              ],
+            },
+          },
+        ];
+        const index  = reconciler.prepare(concepts);
+        const result = reconciler.resolveFailure(
+          { url: 'https://2e.aonprd.com/Ancestries.aspx?ID=9', errors: [] },
+          index,
+        );
+        assert.deepEqual(result, { status: 'capturedElsewhere', at: ancestryUrl });
+      });
+    });
+  }
+}
+
+AonprdReconcilerTest.run();

--- a/tests/unit/plugins/aonprd/taxonomy.test.ts
+++ b/tests/unit/plugins/aonprd/taxonomy.test.ts
@@ -5,7 +5,7 @@ import { Batch } from '@studnicky/dagonizer';
 import assert from 'node:assert/strict';
 
 import { RoutedBatchBuilder, Timeout } from '@studnicky/dagonizer';
-import type { NodeContextType } from '@studnicky/dagonizer';
+import type { NodeContextType, SchemaObjectType } from '@studnicky/dagonizer';
 
 import type { ScrapeState }    from '../../../../src/state/ScrapeState.js';
 import { Taxonomy, TaxonomyError } from '../../../../plugins/aonprd/taxonomy.js';
@@ -18,8 +18,9 @@ import type { ConceptDecl, CapabilityNode } from '../../../../plugins/aonprd/tax
 function makeStubCap(name: string): CapabilityNode {
   return {
     name,
-    outputs:  ['success', 'error'] as const,
-    timeout:  Timeout.none(),
+    outputs:      ['success', 'error'] as const,
+    timeout:      Timeout.none(),
+    outputSchema: { success: { type: 'object' }, error: { type: 'object' } } as Record<'success' | 'error', SchemaObjectType>,
     async execute(
       batch: Batch<ScrapeState>,
       _ctx:  NodeContextType,

--- a/tests/unit/registry/builtinTasks.test.ts
+++ b/tests/unit/registry/builtinTasks.test.ts
@@ -5,6 +5,7 @@ import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { NodeContextBuilder } from '@studnicky/dagonizer/entities';
 import type { NodeContextType } from '@studnicky/dagonizer';
 
 import { ScrapeState }         from '../../../src/state/ScrapeState.js';
@@ -35,18 +36,19 @@ const buildState = (overrides: Partial<{
   return state;
 };
 
-const makeContext = (services: Partial<RipperServices>): NodeContextType<RipperServices> => ({
-  services: {
-    log:    Logger.forComponent('test'),
-    cache:  null,
-    target: { id: TARGET },
-    outDir: '',
-    ...services,
-  } as RipperServices,
-  signal:    new AbortController().signal,
-  dagName:   'test',
-  nodeName:  'test',
-});
+const makeContext = (services: Partial<RipperServices>): NodeContextType<RipperServices> =>
+  NodeContextBuilder.of<RipperServices>(
+    'test',
+    'test',
+    new AbortController().signal,
+    {
+      log:    Logger.forComponent('test'),
+      cache:  null,
+      target: { id: TARGET },
+      outDir: '',
+      ...services,
+    } as RipperServices,
+  );
 
 class FakeHtmlScraper {
   public calls: string[] = [];

--- a/tests/unit/resilience/cross-locator.test.ts
+++ b/tests/unit/resilience/cross-locator.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for CrossLocatorStrategy (via LinkResolverRegistry).
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { LinkResolverRegistry } from '../../../src/resilience/LinkResolve.js';
+import type { RipperServices }  from '../../../src/services/RipperServices.js';
+
+// ── Stub HtmlScraper ────────────────────────────────────────────────────────────
+
+const GOOD_CATEGORY = 'Classes';
+
+/**
+ * Minimal stub implementing the `fetchPage` method surface used by CrossLocatorStrategy.
+ * Throws for any category that is not `GOOD_CATEGORY`; resolves for `GOOD_CATEGORY`.
+ */
+class StubHtmlScraper {
+  public async fetchPage(url: string): Promise<{ url: string; html: string; $: unknown }> {
+    if (url.includes(`/${GOOD_CATEGORY}.aspx`)) {
+      return { url, html: '<html></html>', $: {} };
+    }
+    throw new Error(`fetch failed for ${url}`);
+  }
+}
+
+/** Build a minimal RipperServices stub for CrossLocatorStrategy tests. */
+const makeServices = (categorySet: readonly string[]): RipperServices =>
+  ({
+    log: {
+      debug: () => {},
+      info:  () => {},
+      warn:  () => {},
+      error: () => {},
+    },
+    cache:       null,
+    target:      { id: 'test' },
+    outDir:      '/tmp',
+    dispatcher:  {} as RipperServices['dispatcher'],
+    htmlScraper: new StubHtmlScraper() as unknown as RipperServices['htmlScraper'],
+    resolve: {
+      strategies:  ['crossLocator'],
+      categorySet,
+    },
+  }) as unknown as RipperServices;
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+const strategy = LinkResolverRegistry.get('crossLocator');
+assert.ok(strategy !== undefined, 'crossLocator strategy must exist in registry');
+
+describe('CrossLocatorStrategy', () => {
+  it('returns sibling category url when fetchPage resolves for a sibling', async () => {
+    const services  = makeServices(['Ancestries', 'Classes', 'NPCs']);
+    const failedUrl = 'https://aonprd.com/Monsters.aspx?ID=77';
+
+    const result = await strategy.resolve(failedUrl, services);
+
+    assert.equal(result, 'https://aonprd.com/Classes.aspx?ID=77');
+  });
+
+  it('returns null when all candidate categories fail', async () => {
+    const services  = makeServices(['Ancestries', 'NPCs']);
+    const failedUrl = 'https://aonprd.com/Monsters.aspx?ID=77';
+
+    const result = await strategy.resolve(failedUrl, services);
+
+    assert.equal(result, null);
+  });
+
+  it('returns null when the url does not match the <Category>.aspx?ID=<n> pattern', async () => {
+    const services  = makeServices(['Ancestries', 'Classes', 'NPCs']);
+    const failedUrl = 'https://aonprd.com/search?q=goblin';
+
+    const result = await strategy.resolve(failedUrl, services);
+
+    assert.equal(result, null);
+  });
+});

--- a/workers/ParseRegistryModule.ts
+++ b/workers/ParseRegistryModule.ts
@@ -42,6 +42,7 @@ import {
   HtmlWriteRawNode,
   WikiWriteRawNode,
   JsonWriteNode,
+  CaptureErrorNode,
   JsonlAppendNode,
   ValidateSchemaNode,
   TerminalNode,
@@ -49,6 +50,8 @@ import {
   FetchAndExtractLinksNode,
   DedupeAndEnqueueNode,
   CrawlExhaustedNode,
+  RouteFailureNode,
+  ResolveLinkNode,
 } from '../src/nodes/index.js';
 
 import { TAXONOMY }       from '../plugins/aonprd/taxonomy/aonprd.js';
@@ -140,6 +143,7 @@ class ParseRegistryModule implements RegistryModuleInterface<RipperServices> {
       HtmlWriteRawNode,
       WikiWriteRawNode,
       JsonWriteNode,
+      CaptureErrorNode,
       JsonlAppendNode,
       ValidateSchemaNode,
       TerminalNode,
@@ -147,6 +151,8 @@ class ParseRegistryModule implements RegistryModuleInterface<RipperServices> {
       FetchAndExtractLinksNode,
       DedupeAndEnqueueNode,
       CrawlExhaustedNode,
+      RouteFailureNode,
+      ResolveLinkNode,
       ...TAXONOMY.allNodes(),
     ];
 

--- a/workers/StubRegistryModule.ts
+++ b/workers/StubRegistryModule.ts
@@ -51,6 +51,23 @@ type StubServicesType = Record<string, never>;
 const stubEchoNode: NodeInterface<StubState, string, StubServicesType> = {
   name:    'stub:echo',
   outputs: ['done'],
+  // `done` — `state.output` is set to the echoed page url plus a worker marker.
+  outputSchema: {
+    done: {
+      type: 'object',
+      properties: {
+        output: {
+          type: 'object',
+          properties: {
+            url:              { type: 'string' },
+            processedInWorker: { type: 'boolean' },
+          },
+          required: ['url', 'processedInWorker'],
+        },
+      },
+      required: ['output'],
+    },
+  },
   timeout: Timeout.none(),
   async execute(batch) {
     for (const { state } of batch) {


### PR DESCRIPTION
## Summary
Release `3.2.0`: `@studnicky/dagonizer` 0.25 adoption + the site-agnostic resilience layer (FailurePolicy/route:failure, error-as-data capture, reconcile:identity + crawl-health report, opt-in resolve:link) + dependency refresh + CodeQL. Validated by a full parallel rip whose `crawl-health.json` proves data completeness automatically (13,887 concepts; the 4 AON 404s resolve to 3 capturedElsewhere + 1 lore-only missing).

## Type of Change
- [x] Feature · Security · Chore (release)

## Testing
- [x] 863 unit · 12 integration · 123 e2e pass; typecheck/lint/build clean; full CI green on the source PR (#73), incl. CodeQL.

## Checklist
- [x] Conventions followed · Self-reviewed · Docs updated · Tests pass

## Related Issues
Follows #73.

By the Omnissiah's grace this rite ships true: failures inscribed as data, completeness proven by the tally, the parallel looms steady.