### PR TITLE
Release 3.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.3] - 2026-06-23
+
 ### Security
 
 - **CodeQL `js/redos` (×3)** — the Title-Case name heuristic regexes in `plugins/aonprd/concepts/{archetype,feat,subclass-feature/helpers}.ts` had a word class (`[A-Za-z'.-]`) overlapping the separator class (`[ '-]`), enabling exponential backtracking. Word atoms are now `[A-Za-z.]` (the `'`/`-` separators no longer double as word characters), eliminating the ambiguity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **CodeQL `js/redos` (×3)** — the Title-Case name heuristic regexes in `plugins/aonprd/concepts/{archetype,feat,subclass-feature/helpers}.ts` had a word class (`[A-Za-z'.-]`) overlapping the separator class (`[ '-]`), enabling exponential backtracking. Word atoms are now `[A-Za-z.]` (the `'`/`-` separators no longer double as word characters), eliminating the ambiguity.
+- **CodeQL `js/double-escaping` + `js/incomplete-multi-character-sanitization`** — `aonprd/common.ts` `htmlToText` (and the mirrored `_test_secondary` / `bulbapedia` strippers) now decode `&amp;` last (so `&amp;lt;` no longer double-unescapes) and strip tags/comments to a fixpoint (so nested/partial `<script`/`<!--` cannot survive). Output is unchanged for well-formed input.
+
 ## [3.2.2] - 2026-06-23
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@studnicky/ripperoni",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@studnicky/ripperoni",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studnicky/ripperoni",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Web ingestion engine; slices wikis, sites, and URL lists into JSON records, one page at a time. Pairs with Squashage for RDF graph reconstitution.",
   "type": "module",
   "private": false,

--- a/plugins/_test_secondary/strategies/secondary.ts
+++ b/plugins/_test_secondary/strategies/secondary.ts
@@ -27,9 +27,18 @@ import type {
  * but kept local so this strategy has zero imports from AON-specific modules.
  */
 function htmlToTextLocal(html: string): string {
-  return html
-    .replace(/<br\s*\/?>/gi, ' ')
-    .replace(/<[^>]+>/g, '')
+  let s = html.replace(/<br\s*\/?>/gi, ' ');
+
+  // Strip tags to fixpoint so nested/malformed tags cannot survive a single pass
+  // (CWE-116 / js/incomplete-multi-character-sanitization).
+  let prev: string;
+  do {
+    prev = s;
+    s = s.replace(/<[^>]+>/g, '');
+  } while (s !== prev);
+
+  // Decode &amp; last so &amp;nbsp; etc. never double-unescape.
+  return s
     .replace(/&nbsp;/g, ' ')
     .replace(/&amp;/g,  '&')
     .replace(/\s+/g,    ' ')

--- a/plugins/aonprd/common.ts
+++ b/plugins/aonprd/common.ts
@@ -476,12 +476,24 @@ export function extractSources(span: CheerioNode): SourceRef[] {
  * the legacy no-space behavior so proper-name italics don't gain artifacts.
  */
 export function htmlToText(html: string): string {
-  return html
+  // Expand <br> to space and insert space between adjacent closing/opening tags
+  // (e.g. <a>Foo</a><a>Bar</a> → "Foo Bar").
+  let s = html
     .replace(/<br\s*\/?>/gi, ' ')
-    .replace(/<\/[a-z][a-z0-9]*\s*>(?=<[a-z])/gi, ' ')
-    .replace(/<[^>]+>/g, '')
+    .replace(/<\/[a-z][a-z0-9]*\s*>(?=<[a-z])/gi, ' ');
+
+  // Strip tags to fixpoint so nested/malformed tags cannot survive a single pass
+  // (CWE-116 / js/incomplete-multi-character-sanitization).
+  let prev: string;
+  do {
+    prev = s;
+    s = s.replace(/<[^>]+>/g, '');
+  } while (s !== prev);
+
+  // Decode named entities. &amp; is decoded LAST so that &amp;lt; in source
+  // never double-unescapes to < (js/double-escaping).
+  return s
     .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&#x27;|&apos;/g, "'")
@@ -490,6 +502,7 @@ export function htmlToText(html: string): string {
     .replace(/&ndash;/g, '–')
     .replace(/&bull;/g, '•')
     .replace(/&times;/g, '×')
+    .replace(/&amp;/g, '&')
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/plugins/aonprd/concepts/archetype.ts
+++ b/plugins/aonprd/concepts/archetype.ts
@@ -370,7 +370,9 @@ function isFlavorBoldLabel(name: string): boolean {
   const core = trimmed.replace(/\s*\([^)]*\)\s*$/, '').trim();
   if (core.length < 3) return false;
   // Multi-word Title-Case (allows lowercase connectors).
-  if (/^[A-Z][A-Za-z'.-]*(?:[ '-](?:[a-z]{1,4}|[A-Z][A-Za-z'.-]*))+$/.test(core)) return true;
+  // Word atoms use [A-Za-z.] (no ' or -) so they are unambiguous against the
+  // [ '-] separator class, eliminating catastrophic backtracking (ReDoS).
+  if (/^[A-Z][A-Za-z.]*(?:[ '-](?:[a-z]{1,4}|[A-Z][A-Za-z.]*))+$/.test(core)) return true;
   // Single-word Title-Case proper name (3+ chars).
   if (/^[A-Z][a-z]{2,}$/.test(core)) return true;
   // Lowercase emphasis word inside flavor prose.

--- a/plugins/aonprd/concepts/feat.ts
+++ b/plugins/aonprd/concepts/feat.ts
@@ -397,7 +397,9 @@ function isFlavorNpcName(name: string): boolean {
   const trimmed = name.trim();
   if (trimmed.length === 0) return false;
   // Multi-word Title-Case (e.g. "Arba Dwindletree", "Queen Galfrey", "Dr. Ashley Arrowbaud").
-  if (/^[A-Z][A-Za-z'.-]*(?:[ '-][A-Z][A-Za-z'.-]*)+$/.test(trimmed)) return true;
+  // Word atoms use [A-Za-z.] (no ' or -) so they are unambiguous against the
+  // [ '-] separator class, eliminating catastrophic backtracking (ReDoS).
+  if (/^[A-Z][A-Za-z.]*(?:[ '-][A-Z][A-Za-z.]*)+$/.test(trimmed)) return true;
   // Single-word Title-Case "stage name" (e.g. "Moloch", "Thais", "Jinx").
   if (/^[A-Z][a-z]{2,}$/.test(trimmed)) return true;
   return false;

--- a/plugins/aonprd/concepts/subclass-feature/helpers.ts
+++ b/plugins/aonprd/concepts/subclass-feature/helpers.ts
@@ -203,7 +203,9 @@ export function isFlavorBoldLabel(name: string): boolean {
   // Adventure-product ID code (e.g. "SC- 04910") — alphabetic prefix + digits.
   if (/^[A-Z]{1,4}[-\s]\s*\d+$/.test(core)) return true;
   // Multi-word Title-Case with optional lowercase connector words.
-  if (/^[A-Z][A-Za-z'.-]*(?:[ '-](?:[a-z]{1,4}|[A-Z][A-Za-z'.-]*))+$/.test(core)) return true;
+  // Word atoms use [A-Za-z.] (no ' or -) so they are unambiguous against the
+  // [ '-] separator class, eliminating catastrophic backtracking (ReDoS).
+  if (/^[A-Z][A-Za-z.]*(?:[ '-](?:[a-z]{1,4}|[A-Z][A-Za-z.]*))+$/.test(core)) return true;
   // Single-word Title-Case proper name (3+ chars: Hew, Gal, Roc, Moloch).
   if (/^[A-Z][a-z]{2,}$/.test(core)) return true;
   return false;

--- a/plugins/bulbapedia/parse.task.ts
+++ b/plugins/bulbapedia/parse.task.ts
@@ -51,8 +51,13 @@ const warnedUnknownKeys = new Set<string>();
 function stripWikiMarkup(raw: string): string {
   // Keep only first <br> segment (first variant when multiple exist)
   let str = raw.split(/<br\s*\/?>/i)[0] ?? raw;
-  // Drop HTML comments
-  str = str.replace(/<!--[\s\S]*?-->/g, '');
+  // Drop HTML comments to fixpoint so nested/partial <!-- cannot survive a
+  // single pass (CWE-116 / js/incomplete-multi-character-sanitization).
+  let prev: string;
+  do {
+    prev = str;
+    str = str.replace(/<!--[\s\S]*?-->/g, '');
+  } while (str !== prev);
   // Resolve {{tt|display|tooltip}} → display
   str = str.replace(/\{\{tt\|([^|}\n]+)\|[^}]*\}\}/gi, '$1');
   // Drop remaining {{ ... }} templates

--- a/tests/unit/plugins/aonprd/common.test.ts
+++ b/tests/unit/plugins/aonprd/common.test.ts
@@ -1,0 +1,87 @@
+// Unit tests for aonprd common.ts utility functions.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { htmlToText } from '../../../../plugins/aonprd/common.js';
+
+describe('htmlToText — tag stripping', () => {
+  it('strips a simple tag', () => {
+    assert.equal(htmlToText('<b>bold</b>'), 'bold');
+  });
+
+  it('inserts space between adjacent closing/opening tags', () => {
+    assert.equal(htmlToText('<a>Taldane</a><a>Nagaji</a>'), 'Taldane Nagaji');
+  });
+
+  it('strips tags to fixpoint — consecutively nested same tags', () => {
+    // Verifies idempotence: a second pass on already-clean output returns the same string,
+    // so the fixpoint loop terminates correctly and does not mutate clean text.
+    assert.equal(htmlToText('<div><b>hello</b></div>'), 'hello');
+  });
+
+  it('strips tags to fixpoint — ensures no tag residue remains after multiple passes', () => {
+    // The fixpoint loop is the defense-in-depth guard required by
+    // CWE-116 / js/incomplete-multi-character-sanitization.
+    // Verify it is idempotent on arbitrary well-formed HTML.
+    const complexHtml = '<p class="x"><strong><em>rich text</em></strong></p>';
+    assert.equal(htmlToText(complexHtml), 'rich text');
+  });
+
+  it('strips tags to fixpoint — double-wrapped tag', () => {
+    assert.equal(htmlToText('<div><span>inner</span></div>'), 'inner');
+  });
+});
+
+describe('htmlToText — entity decoding', () => {
+  it('decodes &lt; and &gt;', () => {
+    assert.equal(htmlToText('a &lt; b &gt; c'), 'a < b > c');
+  });
+
+  it('decodes &amp; to &', () => {
+    assert.equal(htmlToText('foo &amp; bar'), 'foo & bar');
+  });
+
+  it('does NOT double-unescape &amp;lt; — &amp; decoded last', () => {
+    // &amp;lt; should produce &lt; (literal), not < (double-unescape).
+    assert.equal(htmlToText('&amp;lt;'), '&lt;');
+  });
+
+  it('does NOT double-unescape &amp;gt;', () => {
+    assert.equal(htmlToText('&amp;gt;'), '&gt;');
+  });
+
+  it('does NOT double-unescape &amp;amp;', () => {
+    assert.equal(htmlToText('&amp;amp;'), '&amp;');
+  });
+
+  it('decodes &nbsp; to space', () => {
+    assert.equal(htmlToText('foo&nbsp;bar'), 'foo bar');
+  });
+
+  it('decodes &mdash;', () => {
+    assert.equal(htmlToText('a&mdash;b'), 'a—b');
+  });
+
+  it('decodes &ndash;', () => {
+    assert.equal(htmlToText('a&ndash;b'), 'a–b');
+  });
+
+  it('decodes &apos; and &#x27;', () => {
+    assert.equal(htmlToText("it&apos;s"), "it's");
+    assert.equal(htmlToText("it&#x27;s"), "it's");
+  });
+
+  it('decodes &quot;', () => {
+    assert.equal(htmlToText('say &quot;hello&quot;'), 'say "hello"');
+  });
+});
+
+describe('htmlToText — whitespace normalisation', () => {
+  it('collapses multiple spaces', () => {
+    assert.equal(htmlToText('a  b   c'), 'a b c');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    assert.equal(htmlToText('  hello  '), 'hello');
+  });
+});

--- a/tests/unit/plugins/aonprd/concepts/subclass-feature-helpers.test.ts
+++ b/tests/unit/plugins/aonprd/concepts/subclass-feature-helpers.test.ts
@@ -1,0 +1,72 @@
+// Unit tests for subclass-feature/helpers.ts — isFlavorBoldLabel (ReDoS fix).
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isFlavorBoldLabel } from '../../../../../plugins/aonprd/concepts/subclass-feature/helpers.js';
+
+describe('isFlavorBoldLabel — legitimate names (should return true)', () => {
+  it('recognises a two-word Title-Case name', () => {
+    assert.equal(isFlavorBoldLabel('Queen Galfrey'), true);
+  });
+
+  it('recognises a name with a period abbreviation (Dr.)', () => {
+    assert.equal(isFlavorBoldLabel('Dr. Ashley Arrowbaud'), true);
+  });
+
+  it('recognises a hyphenated Title-Case name (Half-Elf)', () => {
+    assert.equal(isFlavorBoldLabel('Half-Elf'), true);
+  });
+
+  it('recognises a name with lowercase connector (van, of, the)', () => {
+    assert.equal(isFlavorBoldLabel('Queen of Hearts'), true);
+  });
+
+  it('recognises a single Title-Case proper name (Moloch)', () => {
+    assert.equal(isFlavorBoldLabel('Moloch'), true);
+  });
+
+  it('recognises an adventure product ID (SC- 04910)', () => {
+    assert.equal(isFlavorBoldLabel('SC- 04910'), true);
+  });
+});
+
+describe('isFlavorBoldLabel — should return false for non-name labels', () => {
+  it('rejects a plain lowercase word', () => {
+    assert.equal(isFlavorBoldLabel('damage'), false);
+  });
+
+  it('rejects a two-character string', () => {
+    assert.equal(isFlavorBoldLabel('ab'), false);
+  });
+
+  it('rejects an empty string', () => {
+    assert.equal(isFlavorBoldLabel(''), false);
+  });
+
+  it('rejects ALL-CAPS acronym', () => {
+    assert.equal(isFlavorBoldLabel('HP'), false);
+  });
+});
+
+describe('isFlavorBoldLabel — ReDoS regression (must complete near-instantly)', () => {
+  it('does not hang on a long repeated ambiguous separator sequence', () => {
+    // Prior regex had overlapping ' and - in both word class [A-Za-z'.-]
+    // and separator class [ '-], causing catastrophic backtracking.
+    // This input forces maximum backtracking on the vulnerable pattern.
+    const redosInput = "A' A' A' A' A' A' A' A' A' A' A' A' A' A' A' A' A' A' A' A'X";
+    const start = Date.now();
+    isFlavorBoldLabel(redosInput);
+    const elapsed = Date.now() - start;
+    // Should complete in well under 1 second on any machine; catastrophic
+    // backtracking on the old regex would take many seconds or timeout.
+    assert.ok(elapsed < 500, `ReDoS triggered: took ${elapsed}ms`);
+  });
+
+  it('does not hang on long hyphen-separated input', () => {
+    const redosInput = 'A-A-A-A-A-A-A-A-A-A-A-A-A-A-A-A-A-A-A-AX';
+    const start = Date.now();
+    isFlavorBoldLabel(redosInput);
+    const elapsed = Date.now() - start;
+    assert.ok(elapsed < 500, `ReDoS triggered: took ${elapsed}ms`);
+  });
+});


### PR DESCRIPTION
## Summary
Patch release **3.2.3** — security fast-follow. Resolves the open CodeQL code-scanning findings: 7 fixed in code (3× `js/redos`, `js/double-escaping`, 3× `js/incomplete-multi-character-sanitization`) with regression tests; 11 dismissed with justification (scraper-by-design `file-access-to-http`, test-only patterns). Merging to master triggers publish + Pages.

## Type of Change
- [ ] Feature (new functionality)
- [x] Bug fix (non-breaking fix)
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Chore

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

## Checklist
- [x] Code follows project conventions (typecheck + lint clean)
- [x] CHANGELOG.md updated under `## [3.2.3] - 2026-06-23`
- [x] No real target names introduced (target-neutrality gate passes)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] All tests pass

## Related Issues
CodeQL code-scanning remediation. Follows 3.2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
