### PR TITLE
ci: grant packages:read to Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   pages: write
   id-token: write
 


### PR DESCRIPTION
## Summary
The Pages deploy fails with E403 reading the private `@studnicky/dagonizer*` packages: the workflow has the `.npmrc` auth step but its `permissions:` block lacks `packages: read`, so `GITHUB_TOKEN` is forbidden from the org package. Adds `packages: read` (matching `ci.yml`/`security.yml`). CI-only fix; no version change.

## Type of Change
- [ ] Feature (new functionality)
- [ ] Bug fix (non-breaking fix)
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Chore

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed

## Checklist
- [x] Code follows project conventions (typecheck + lint clean)
- [x] CHANGELOG.md updated under `## [3.2.3] - 2026-06-23`
- [x] No real target names introduced (target-neutrality gate passes)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] All tests pass

## Related Issues
Fixes the Pages deploy E403 after #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
